### PR TITLE
Rename "settings" to "configurations"

### DIFF
--- a/docs/source/_ext/generate_instrument_docs.py
+++ b/docs/source/_ext/generate_instrument_docs.py
@@ -98,32 +98,32 @@ def generate_rst(data):
 
             model_data['sphinx_link'] = link
 
-            if not model_data['settings']:
-                out += 'Settings: NONE\n\n'
+            if not model_data['configurations']:
+                out += 'Configurations: NONE\n\n'
                 continue
             else:
-                out += 'Settings:\n\n'
+                out += 'Configurations:\n\n'
 
-            for setting_name, setting_data in model_data['settings'].items():
-                setting_link = f'{version_name}-{model_name}-{setting_name}-data'
-                out += f'* :iref:ref:`{setting_name}<{setting_link}>`\n\n'
+            for config_name, config_data in model_data['configurations'].items():
+                config_link = f'{version_name}-{model_name}-{config_name}-data'
+                out += f'* :iref:ref:`{config_name}<{config_link}>`\n\n'
 
-                default_setting = setting_data['default_setting']
-                for option_name in setting_data.keys():
-                    link = f'{version_name}-{model_name}-{setting_name}-{option_name}-data'
+                default_option = config_data['default_option']
+                for option_name in config_data.keys():
+                    link = f'{version_name}-{model_name}-{config_name}-{option_name}-data'
 
-                    if option_name == 'default_setting':
+                    if option_name == 'default_option':
                         continue
                     else:
                         out += f'  * :iref:ref:`{option_name}<{link}>`'
-                        setting_data[option_name]['sphinx_link'] = link
+                        config_data[option_name]['sphinx_link'] = link
 
-                        if option_name == default_setting:
+                        if option_name == default_option:
                             out +=  ' (default)\n'
                         else:
                             out += '\n'
 
-                setting_data['sphinx_link'] = setting_link
+                config_data['sphinx_link'] = config_link
 
                 out += '\n'
 
@@ -169,7 +169,7 @@ def generate_data_section(data_with_links: dict, target_role: str = ':iref:targe
             out += ' ' * 16 + f'{target_role}`{model_name}<{link}>`:\n'
 
             for key, value in model_data.items():
-                if key in ['parameters', 'settings', 'sphinx_link']:
+                if key in ['parameters', 'configurations', 'sphinx_link']:
                     continue
 
                 out += ' ' * 20 + f'{key}: {format_value(value)}\n'
@@ -178,21 +178,21 @@ def generate_data_section(data_with_links: dict, target_role: str = ':iref:targe
 
             out += add_parameters(model_data['parameters'], 24)
 
-            out += ' ' * 20 + f'settings:'
+            out += ' ' * 20 + f'configurations:'
 
-            if not model_data['settings']:
+            if not model_data['configurations']:
                 out += ' {}\n'
                 continue
 
             out += '\n'
 
-            for setting_name, setting_data in model_data['settings'].items():
-                link = setting_data['sphinx_link']
-                out += ' ' * 24 + f'{target_role}`{setting_name}<{link}>`:\n'
-                out += ' ' * 28 + f'default_setting: "{setting_data["default_setting"]}"\n'
+            for config_name, config_data in model_data['configurations'].items():
+                link = config_data['sphinx_link']
+                out += ' ' * 24 + f'{target_role}`{config_name}<{link}>`:\n'
+                out += ' ' * 28 + f'default_option: "{config_data["default_option"]}"\n'
 
-                for option_name, option_data in setting_data.items():
-                    if option_name in ['sphinx_link', 'default_setting']:
+                for option_name, option_data in config_data.items():
+                    if option_name in ['sphinx_link', 'default_option']:
                         continue
 
                     link = option_data['sphinx_link']

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -38,16 +38,24 @@ Most relevant terms
         upgrade significant enough to alter the :term:`resolution` is done, a new "version" is
         created for that :term:`instrument`.
 
-    setting
-        A set of :term:`options<option>` that can be made for a particular :term:`version` of a
-        particular :term:`instrument`. This can be, for example, the choice of the
-        :term:`Fermi chopper` parameters.
+    configuration
+        A set of :term:`options<option>` built into an :term:`instrument` that change the physical
+        configuration of the :term:`instrument`, affecting the :term:`resolution`. These are things
+        such as the choice of :term:`Fermi chopper` or analyser. In the context of this library,
+        this is a set of instrument parameters, grouped by a name (:term:`option`), which get
+        provided to a :term:`model` together with the constant parameters.
 
     option
-        One of the options that can be chosen for a given :term:`setting`. This is tied to a
-        particular :term:`version` of a particular :term:`instrument`. For example, if a
-        :term:`Fermi chopper` is a :term:`setting`, the "option" is one of the choices that can be
-        made for that :term:`Fermi chopper`.
+        One of the options that can be chosen for a given :term:`configuration`. This is tied to a
+        particular :term:`version` of a particular :term:`instrument`. Any given INS instrument may
+        have several :term:`options<option>` for a given :term:`configuration` for users to choose
+        from, which affect several parameters of that instrument.
+
+    setting
+        A user-chosen experimental parameter that affects the :term:`resolution`. In practice, this
+        can be the incident energy and the chopper frequencies, depending on the :term:`instrument.
+        In the context of this library, a :term:`setting` is an argument specifically required by a
+        :term:`model`.
 
     model
         A method to represent the :term:`resolution function`. There are different ways of

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -53,7 +53,7 @@ Most relevant terms
 
     setting
         A user-chosen experimental parameter that affects the :term:`resolution`. In practice, this
-        can be the incident energy and the chopper frequencies, depending on the :term:`instrument.
+        can be the incident energy and the chopper frequencies, depending on the :term:`instrument`.
         In the context of this library, a :term:`setting` is an argument specifically required by a
         :term:`model`.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,8 +4,8 @@ ResINS
 Python library for working with resolution functions of inelastic neutron
 scattering (INS) instruments. This package exists to centralise all things related to resolution of
 INS instruments and make it easier to work with. It pools related code from existing projects,
-namely :ref:`AbINS <https://github.com/mantidproject/mantid/tree/main/scripts/abins>`_ and
-:ref:`PyChop <https://github.com/mducle/pychop/tree/main>`_, as well as implementing code
+namely `AbINS <https://github.com/mantidproject/mantid/tree/main/scripts/abins>`_ and
+`PyChop <https://github.com/mducle/pychop/tree/main>`_, as well as implementing code
 published in literature. The main purposes are:
 
 1. Provide one, central place implementing various models for INS instruments (resolution functions)

--- a/docs/source/instruments.rst
+++ b/docs/source/instruments.rst
@@ -3,8 +3,8 @@ Instruments
 
 This section contains the data associated with each supported :term:`instrument`. It lists its
 available :term:`versions<version>` and the :term:`models<model>` available for each :term:`version`.
-The :term:`settings<setting>` and their :term:`options<option>` are similarly listed. All of this
-information is provided to help with the construction of the
+The :term:`configurations<configuration>` and their :term:`options<option>` are similarly listed.
+All of this information is provided to help with the construction of the
 :py:class:`resolution_functions.Instrument` object and subsequent acquisition of the resolution
 function.
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -12,8 +12,9 @@ Instrument(name='TOSCA', version='TOSCA', models=['AbINS', 'book', 'vision'])
 To get the :term:`resolution function`, a couple choices might be necessary:
 
 1. Choose the :term:`model` for our instrument.
-2. Select one of the :term:`options<option>` for each :term:`setting` of the
-   chosen model.
+2. Select one of the :term:`options<option>` for each :term:`configuration` of
+   the chosen model.
+3. Provide any other :term:`settings<setting>` that the model requires.
 
 If we don't know what the possibilities are for the chosen instrument, the
 information can be found either in the :doc:`documentation<instruments>` or
@@ -30,8 +31,8 @@ via the
 method:
 
 >>> book = tosca.get_resolution_function('book', detector_bank='Forward')
->>> book
-<resolution_functions.models.tosca_book.ToscaBookModel object at 0x000000000>
+>>> print(book)
+ToscaBookModel(citation="")
 
 .. note::
 

--- a/src/resolution_functions/instrument.py
+++ b/src/resolution_functions/instrument.py
@@ -426,10 +426,10 @@ class Instrument:
         except KeyError:
             raise InvalidModelError(model_name, self)
 
-        available_settings = model['settings']
+        available_configurations = model['configurations']
 
         settings = []
-        for setting_name, options in available_settings.items():
+        for setting_name, options in available_configurations.items():
             kwarg = kwargs.pop(setting_name, None)
             if kwarg is None:
                 kwarg = options['default_setting']

--- a/src/resolution_functions/instrument.py
+++ b/src/resolution_functions/instrument.py
@@ -62,10 +62,10 @@ class InvalidModelError(Exception):
         super().__init__(message)
 
 
-class InvalidSettingError(Exception):
+class InvalidConfigurationError(Exception):
     """
-    An Exception representing an invalid user input for the :term:`setting` of a :term:`model` of 
-    an :term:`instrument`.
+    An Exception representing an invalid user input for the :term:`configuration` of a :term:`model`
+    of an :term:`instrument`.
 
     This class does not support an arbitrary message; instead the message is constructed in here
     from the provided information.
@@ -73,16 +73,17 @@ class InvalidSettingError(Exception):
     Parameters
     ----------
     provided_name
-        The invalid name for the setting that the user provided.
+        The invalid name for the configuration that the user provided.
     model_name
         The name of the model for which the `provided_name` was provided.
     instrument
         The instance of the `Instrument` object in which the `provided_name` was used.
     """
     def __init__(self, provided_name: str, model_name: str, instrument: Instrument):
-        message = f'"{provided_name}" is not a valid setting for the {model_name} model of the ' \
-                  f'{instrument.version} version of the {instrument.name} instrument. This ' \
-                  f'instrument only supports the following models: {instrument.available_models}.'
+        message = f'"{provided_name}" is not a valid configuration for the {model_name} model of ' \
+                  f'the {instrument.version} version of the {instrument.name} instrument. This ' \
+                  f'instrument only supports the following configurations: ' \
+                  f'{instrument.possible_configurations_for_model(model_name)}.'
 
         super().__init__(message)
 
@@ -99,8 +100,8 @@ class Instrument:
     associated data.
 
     To be precise, it holds all information about one :term:`version` of an :term:`instrument` (for
-    more about :term:`instrument` versions, see ...), which makes it the centrepiece of this
-    library; the data is necessary for computing the
+    more about :term:`instrument` versions, see :doc:`instruments`), which makes it the centrepiece
+    of this library; the data is necessary for computing the
     :term:`resolution functions<resolution function>`.
 
     However, this information is static and curated by the library, which is why `Instrument` is a
@@ -131,9 +132,8 @@ class Instrument:
         The version of the INS instrument represented by this instance.
     default_model
         The name of the model for this version of this INS instrument that is used by default.
-    available_versions
     available_models
-    available_models_and_settings
+    available_models_and_configurations
     all_available_models_options
     """
     name: str
@@ -363,11 +363,15 @@ class Instrument:
         """
         Retrieves the physical parameters associated with the specified `model_name`.
 
-        This method can be used for inspecting the parameters of a particular :term:`model`, but
-        cannot be used to modify them. It returns a subclass of the `ModelData` class corresponding to the
-        particular model. Another use for this method is to inspect the default values for the
-        model's parameters, as well as any restrictions that they might have, via the
-        `ModelData.restrictions` and `ModelData.defaults` attributes.
+        This method can be used for inspecting the parameters of a particular :term:`model`, though
+        it cannot be used to modify them. It returns a subclass of the
+        `~resolution_functions.models.model_base.ModelData` class corresponding to the
+        particular model.
+
+        Another use for this method is to inspect the default values for the
+        model's :term:`settings<setting>`, as well as any restrictions that they might have, via the
+        `~resolution_functions.models.model_base.ModelData.defaults` and
+        `~resolution_functions.models.model_base.ModelData.restrictions` attributes.
 
         Parameters
         ----------
@@ -375,8 +379,11 @@ class Instrument:
             The name of the model whose parameters to retrieve. If not provided, the parameters of
             the default_model will be retrieved.
         **kwargs
-            Keyword arguments can be passed in to choose an option for each of settings specific to
-            the `model_name`. If not provided, default values are used.
+            Keyword arguments can be passed in to choose an :term:`option` for each
+            :term:`configuration` specific to the `model_name`. If not provided, default values are
+            used. These are mainly useful when checking the :term:`instrument` parameters, but for
+            some :term:`models<model>`, the :term:`options<option>` may also affect the ``defaults``
+            and ``restrictions``.
 
         Returns
         -------
@@ -387,7 +394,7 @@ class Instrument:
         --------
         default_model : The default model for this instrument.
         available_models : List of models available for this instrument
-        possible_settings_for_model : List of settings that can be chosen for this model.
+        possible_configurations_for_model : List of configurations that can be chosen for this model
         """
         out, _ = self._get_model_data(model_name, **kwargs)
         return out
@@ -402,8 +409,8 @@ class Instrument:
             The name of the model whose parameters to retrieve. If not provided, the parameters of
             the default_model will be retrieved.
         kwargs
-            Keyword arguments can be passed in to choose an option for each of settings specific to
-            the `model_name`. If not provided, default values are used.
+            Keyword arguments can be passed in to choose an option for each configuration specific
+            to the `model_name`. If not provided, default values are used.
 
         Returns
         -------
@@ -428,44 +435,49 @@ class Instrument:
 
         available_configurations = model['configurations']
 
-        settings = []
-        for setting_name, options in available_configurations.items():
-            kwarg = kwargs.pop(setting_name, None)
+        configurations = []
+        for configuration_name, options in available_configurations.items():
+            kwarg = kwargs.pop(configuration_name, None)
             if kwarg is None:
                 kwarg = options['default_option']
 
-            settings.append(options[kwarg])
+            configurations.append(options[kwarg])
 
         model_class = MODELS[model['function']]
-        return model_class.data_class(function=model['function'],
-                                      citation=model['citation'],
-                                      **ChainMap(*settings, model['parameters'])), model_name
+        model = model_class.data_class(function=model['function'],
+                                       citation=model['citation'],
+                                       **ChainMap(*configurations, model['parameters']))
+        return model, model_name
 
     def get_resolution_function(self, model_name: Optional[str] = None, **kwargs) -> InstrumentModel:
         """
-        Generates a :term:`resolution function`, as modelled by the `model_name` :term:`model`, for
-        a set of parameters.
+        Generates a :term:`resolution function`, as modelled by the `model_name` :term:`model`.
 
         This method is the main use case of the `Instrument` class. It generates a callable object
         that, when called, returns the :term:`resolution` of the :term:`instrument` at an energy
-        value(s).
+        and/or momentum value(s).
 
         However, while a simple, common interface is provided, different :term:`models<model>` (and
-        sometimes the same :term:`model` for different :term:`instruments!<instrument>`) require
-        different :term:`settings<setting>` to be chosen and different parameters to be provided.
+        sometimes the same :term:`model` for different :term:`instruments<instrument>`!) require
+        different :term:`configurations<configuration>` to be selected and different
+        :term:`settings<setting>` to be provided.
         All of these have to be passed in as keyword arguments (though sensible defaults are
         provided). These keyword arguments correspond to physical user choices made when running an
         INS experiment on the corresponding :term:`instrument`. For example, direct instruments
-        have a tunable incident energy, so their models usually require an ``e_init`` parameter.
+        have a tunable incident energy, so their models usually require an ``e_init``
+        :term:`setting`.
+
         For more information about a model, please see its corresponding documentation,
         or for programmatic querying, please see "How to programmatically query model".
 
         Parameters
         ----------
         model_name
-            The name of the model to instantiate. If not provided, the `default_model` is used.
+            The name of the model to instantiate. If not provided, the `Instrument.default_model` is
+            used.
         **kwargs
-            Keyword arguments specifying the various settings and parameters of the `model_name` model
+            Keyword arguments specifying the various :term:`configurations<configuration>` and
+            :term:`settings<setting>` of the `model_name` model
 
         Returns
         -------
@@ -521,7 +533,7 @@ class Instrument:
         `get_resolution_function` method required when calling it for the `model_name`
         :term:`model`. This is useful because its default signature uses the ``**kwargs`` construct
         to provide a unified interface, but in fact different :term:`models<model>` require
-        different sets of parameters that have to be passed in through the keyword arguments.
+        different sets of values that have to be passed in through the keyword arguments.
 
         There are other methods and properties that can be used to inspect some of the options, but
         this method retrieves all the information and returns it as an `inspect.Signature` object
@@ -547,8 +559,8 @@ class Instrument:
         See Also
         --------
         available_models : List of models available for this version of this instrument.
-        get_model_data : Allows for checking the default values of and restrictions on model parameters.
-        possible_options_for_model : Lists the settings and their options for a model.
+        get_model_data : Allows for checking the default values of and restrictions on model settings.
+        possible_options_for_model : Lists the configurations and their options for a model.
 
         Examples
         --------
@@ -620,16 +632,16 @@ class Instrument:
     @property
     def available_models_and_configurations(self) -> dict[str, list[str]]:
         """
-        A dictionary mapping each available :term:`model` to the user :term:`settings<setting>`
-        available for that :term:`model`.
+        A dictionary mapping each available :term:`model` to the user
+        :term:`configurations<configuration>` available for that :term:`model`.
 
         All :term:`models<model>` available for this :term:`version` of this :term:`instrument`,
-        and all their :term:`settings<setting>` are listed.
+        and all their :term:`configurations<configuration>` are listed.
 
         Returns
         -------
-        models_and_settings
-            All models and all their settings.
+        models_and_configurations
+            All models and all their configurations.
         """
         return {model_name: list(model['configurations'].keys())
                 for model_name, model in self._models.items()}
@@ -637,17 +649,17 @@ class Instrument:
     @property
     def all_available_models_options(self) -> dict[str, dict[str, list[str]]]:
         """
-        A dictionary mapping each available :term:`model`, to the user :term:`settings<setting>`
-        and its :term:`options<option>`.
+        A dictionary mapping each available :term:`model`, to the user
+        :term:`configurations<configuration>` and their :term:`options<option>`.
 
         All :term:`models<model>` available for this :term:`version` of this :term:`instrument`, all
-        the :term:`settings<setting>` of each of the :term:`models<model>`, and all the
-        :term:`options<option>` for each of the :term:`settings<setting>`, are listed.
+        the :term:`configurations<configuration>` of each of the :term:`models<model>`, and all the
+        :term:`options<option>` for each of the :term:`configurations<configuration>`, are listed.
 
         Returns
         -------
         everything
-            All models, all their settings, and all their options.
+            All models, all their configurations, and all their options.
         """
         return {model_name: {config: self._get_options(value)
                              for config, value in list(model['configurations'].items())}
@@ -655,17 +667,18 @@ class Instrument:
 
     def possible_configurations_for_model(self, model_name: str) -> list[str]:
         """
-        Returns all the :term:`settings<setting>` that the `model_name` :term:`model` supports.
+        Returns all the :term:`configurations<configuration>` that the `model_name` :term:`model`
+        supports.
 
         Parameters
         ----------
         model_name
-            The name of the model whose settings to retrieve.
+            The name of the model whose configurations to retrieve.
 
         Returns
         -------
-        settings
-            A list of settings available for the `model_name` model.
+        configurations
+            A list of configurations available for the `model_name` model.
 
         Raises
         ------
@@ -681,18 +694,19 @@ class Instrument:
 
     def possible_options_for_model(self, model_name: str) -> dict[str, list[str]]:
         """
-        Returns a dictionary mapping all the :term:`settings<setting>` of the `model_name`
-        :term:`model` to their :term:`options<option>`.
+        Returns a dictionary mapping all the :term:`configurations<configuration>` of the
+        `model_name` :term:`model` to their :term:`options<option>`.
 
         Parameters
         ----------
         model_name
-            The name of the model whose settings to retrieve.
+            The name of the model whose configurations to retrieve.
 
         Returns
         -------
-        settings_and_options
-            All the settings available for the `model_name` model and all their possible options.
+        configurations_and_options
+            All the configurations available for the `model_name` model and all their possible
+            options.
 
         Raises
         ------
@@ -711,27 +725,28 @@ class Instrument:
                                                      model_name: str,
                                                      configuration: str) -> list[str]:
         """
-        Lists each :term:`option` that can be chosen for a given :term:`setting` of the `model_name`
-        :term:`model`.
+        Lists each :term:`option` that can be chosen for a given :term:`configuration` of the
+        `model_name` :term:`model`.
 
         Parameters
         ----------
         model_name
-            The name of the model to which the `setting` belongs.
-        setting
-            The name of the setting whose to retrieve.
+            The name of the model to which the `configuration` belongs.
+        configuration
+            The name of the configuration whose options to retrieve.
 
         Returns
         -------
         options
-            A list of options available for the `setting` and `model_name`.
+            A list of options available for the `configuration` and `model_name`.
 
         Raises
         ------
         InvalidModelError
             If the provided `model_name` is not supported for this version of this instrument.
-        InvalidSettingError
-            If the provided `setting` is not supported for the `model_name` model of this instrument.
+        InvalidConfigurationError
+            If the provided `configuration` is not supported for the `model_name` model of this
+            instrument.
         """
         try:
             model = self._models[model_name]
@@ -743,53 +758,56 @@ class Instrument:
         try:
             configurations = configurations[configuration]
         except KeyError:
-            raise InvalidSettingError(configuration, model_name, self)
+            raise InvalidConfigurationError(configuration, model_name, self)
 
         return self._get_options(configurations)
 
     @staticmethod
     def _get_options(configuration: dict[str, Union[str, dict]]) -> list[str]:
         """
-        Retrieves all the possible options from ``self._models[model_name]['settings'][setting]``.
+        Retrieves all the possible options from
+        ``self._models[model_name]['configurations'][configuration]``.
 
         Private method that takes the subset of the raw data in ``_models`` that corresponds to one
-        setting of one model, and lists the options, ignoring the ``default_setting`` parameter.
+        configuration of one model, and lists the options, ignoring the ``default_configuration``
+        parameter.
 
         Parameters
         ----------
-        setting
-            A dictionary corresponding to one setting of one model, containing all the options.
+        configuration
+            A dictionary corresponding to one configuration of one model, containing all the options.
 
         Returns
         -------
         options
-            A list of options as found in the provided `setting` dictionary.
+            A list of options as found in the provided `configuration` dictionary.
         """
         return [value for value in configuration.keys() if value != 'default_option']
 
     def default_option_for_configuration(self, model_name: str, configuration: str) -> str:
         """
-        Returns the default :term:`option` for the `setting` :term:`setting` of the `model_name`
+        Returns the default :term:`option` for the `configuration` :term:`configuration` of the `model_name`
         :term:`model` of this :term:`instrument`.
 
         Parameters
         ----------
         model_name
-            The name of the model whose `setting` to look up.
-        setting
-            The name of the setting whose default option to retrieve.
+            The name of the model whose `configuration` to look up.
+        configuration
+            The name of the configuration whose default option to retrieve.
 
         Returns
         -------
         default_option
-            The default option for the `setting` setting.
+            The default option for the `configuration` configuration.
 
         Raises
         ------
         InvalidModelError
             If the provided `model_name` is not supported for this version of this instrument.
-        InvalidSettingError
-            If the provided `setting` is not supported for the `model_name` model of this instrument.
+        InvalidConfigurationError
+            If the provided `configuration` is not supported for the `model_name` model of this
+            instrument.
         """
         try:
             model = self._models[model_name]
@@ -801,6 +819,6 @@ class Instrument:
         try:
             configurations = configurations[configuration]
         except KeyError:
-            raise InvalidSettingError(configuration, model_name, self)
+            raise InvalidConfigurationError(configuration, model_name, self)
 
         return configurations['default_option']

--- a/src/resolution_functions/instrument_data/arcs.yaml
+++ b/src/resolution_functions/instrument_data/arcs.yaml
@@ -34,9 +34,9 @@ version:
                 Fermi:
                     distance: 11.61  # m
                     aperture_distance: 9.342  # m
-        settings: &settings
+        configurations: &configurations
             chopper_package:
-                default_setting: 'ARCS-100-1.5-AST'
+                default_option: 'ARCS-100-1.5-AST'
                 SEQ-100-2.0-AST:
                     pslit: 2.03e-3  # m
                     radius: 50.0e-3  # m
@@ -79,4 +79,4 @@ version:
                 citation: ""
                 parameters:
                     <<: *constants
-                settings: *settings
+                configurations: *configurations

--- a/src/resolution_functions/instrument_data/cncs.yaml
+++ b/src/resolution_functions/instrument_data/cncs.yaml
@@ -93,9 +93,9 @@ version:
                 width: 1.e-2  # Width (m)
                 height: 6.e-2  # Height (m)
                 gamma: 0.0  # Angle of x-axis to ki (degrees)
-        settings: &settings
+        configurations: &configurations
             chopper_package:
-                default_setting: 'High Flux'
+                default_option: 'High Flux'
                 High Flux:
                     choppers:
                         <<: *choppers
@@ -121,4 +121,4 @@ version:
                 citation: ""
                 parameters:
                     <<: *constants
-                settings: *settings
+                configurations: *configurations

--- a/src/resolution_functions/instrument_data/hyspec.yaml
+++ b/src/resolution_functions/instrument_data/hyspec.yaml
@@ -71,9 +71,9 @@ version:
                 Fermi:
                     distance: 37.17  # m
                     aperture_distance: 37.0  # m
-        settings: &settings
+        configurations: &configurations
             chopper_package:
-                default_setting: 'OnlyOne'
+                default_option: 'OnlyOne'
                 OnlyOne:
                     pslit: 0.6e-3  # m
                     radius: 5.0e-3  # m
@@ -86,4 +86,4 @@ version:
                 citation: ""
                 parameters:
                     <<: *constants
-                settings: *settings
+                configurations: *configurations

--- a/src/resolution_functions/instrument_data/lagrange.yaml
+++ b/src/resolution_functions/instrument_data/lagrange.yaml
@@ -9,9 +9,9 @@ version:
             scattering_angle_range: [10, 90]
             angles_per_detector: 5
             energy_bin_width: 1.0  # Default bin width in wavenumber
-        settings: &lagrange_settings
+        configurations: &lagrange_configurations
             monochromator:
-                default_setting: "Cu(220)"
+                default_option: "Cu(220)"
                 Cu(220):
                     #ei_range: [26, 500]  # meV
                     fit: [-3.5961e-2, 2.156e-2, 7.6987e-5, ]  # meV
@@ -32,4 +32,4 @@ version:
                 function: "discontinuous_polynomial"
                 citation: ""
                 parameters: {}
-                settings: *lagrange_settings
+                configurations: *lagrange_configurations

--- a/src/resolution_functions/instrument_data/let.yaml
+++ b/src/resolution_functions/instrument_data/let.yaml
@@ -74,9 +74,9 @@ version:
                 parameters: [0.535, 49.28, -3.143]      # Parameters for time profile
             detector: null
             sample: null
-        settings: &settings
+        configurations: &configurations
             chopper_package:
-                default_setting: 'High Flux'
+                default_option: 'High Flux'
                 High Flux:
                     frequency_matrix:
                       [ [ 0, 0.5 ],                  #   f1: The frequency of the resolution chopper (Disk 5)
@@ -120,4 +120,4 @@ version:
                 citation: ""
                 parameters:
                     <<: *constants
-                settings: *settings
+                configurations: *configurations

--- a/src/resolution_functions/instrument_data/maps.yaml
+++ b/src/resolution_functions/instrument_data/maps.yaml
@@ -46,9 +46,9 @@ version:
                 Fermi:
                     distance: 10.143  # m
                     aperture_distance: 8.27  # m
-        settings: &maps_settings
+        configurations: &maps_configurations
             chopper_package:
-                default_setting: 'A'
+                default_option: 'A'
                 A:
                     pslit: 1.087e-3  # m
                     radius: 49.0e-3  # m
@@ -71,7 +71,7 @@ version:
                 citation: ""
                 parameters:
                     <<: *maps_constants
-                settings: *maps_settings
+                configurations: *maps_configurations
 #            PyChop_tau:
 #                function: "2d_tau"
 #                parameters:

--- a/src/resolution_functions/instrument_data/mari.yaml
+++ b/src/resolution_functions/instrument_data/mari.yaml
@@ -44,9 +44,9 @@ version:
                 Fermi:
                     distance: 10.05  # m
                     aperture_distance: 7.19  # m
-        settings: &mari_settings
+        configurations: &mari_configurations
             chopper_package:
-                default_setting: 'A'
+                default_option: 'A'
                 A:
                     pslit: 0.760e-3  # m
                     radius: 49.0e-3  # m
@@ -70,7 +70,7 @@ version:
                     radius: 10.0e-3          # Chopper package radius (mm)
                     rho: 0.8            # Chopper package curvature (mm)
                     tjit: 0.0             # Jitter time (us)
-                    allowed_e_init: [ 0, 181 ]   # Limits on ei for this chopper (setting Ei outside this will give error)
+                    allowed_e_init: [ 0, 181 ]   # Limits on ei for this chopper (configuration Ei outside this will give error)
                 R:
                     pslit: 1.143e-3          # Neutron transparent slit width (mm)
                     radius: 49.0e-3          # Chopper package radius (mm)
@@ -90,4 +90,4 @@ version:
                 citation: ""
                 parameters:
                     <<: *mari_constants
-                settings: *mari_settings
+                configurations: *mari_configurations

--- a/src/resolution_functions/instrument_data/merlin.yaml
+++ b/src/resolution_functions/instrument_data/merlin.yaml
@@ -44,9 +44,9 @@ version:
                 Fermi:
                     distance: 9.995  # m
                     aperture_distance: 7.19  # m
-        settings: &settings
+        configurations: &configurations
             chopper_package:
-                default_setting: 'G'
+                default_option: 'G'
                 G:
                     pslit: 0.2e-3  # m
                     radius: 5.0e-3  # m
@@ -66,4 +66,4 @@ version:
                 citation: ""
                 parameters:
                     <<: *constants
-                settings: *settings
+                configurations: *configurations

--- a/src/resolution_functions/instrument_data/panther.yaml
+++ b/src/resolution_functions/instrument_data/panther.yaml
@@ -6,7 +6,7 @@ version:
         constants: &PANTHER_CONSTANTS
             q_size: 100
             e_init: 150 # meV
-        settings: {}
+        configurations: {}
         default_model: "AbINS"
         models:
             AbINS:
@@ -15,7 +15,7 @@ version:
                 # (Here a quartic polynomial in ɛ, plus quadratic on Ei and cubic on ɛ×Ei)
                 function: "panther_abins_polynomial"
                 citation: ""
-                settings: {}
+                configurations: {}
                 parameters:
                     abs:
                         [9.776165626074981, 0.023616411911882462, 0.0006472263718719711, 1.4819832651359686e-06]  # abs_meV

--- a/src/resolution_functions/instrument_data/sequoia.yaml
+++ b/src/resolution_functions/instrument_data/sequoia.yaml
@@ -32,9 +32,9 @@ version:
                 Fermi:
                     distance: 18.01  # m
                     aperture_distance: 17.0  # m
-        settings: &settings
+        configurations: &configurations
             chopper_package:
-                default_setting: 'ARCS-100-1.5-AST'
+                default_option: 'ARCS-100-1.5-AST'
                 Fine:
                     pslit: 1.087e-3  # m
                     radius: 49.0e-3  # m
@@ -87,4 +87,4 @@ version:
                 citation: ""
                 parameters:
                     <<: *constants
-                settings: *settings
+                configurations: *configurations

--- a/src/resolution_functions/instrument_data/tosca.yaml
+++ b/src/resolution_functions/instrument_data/tosca.yaml
@@ -17,9 +17,9 @@ version:
             sample_width: 0.02  # m
             detector_width: 0.012  # m
             crystal_plane_spacing: 3.348e-10  # m
-        settings: &tfxa_settings
+        configurations: &tfxa_configurations
             detector_bank:
-                default_setting: "Backward"
+                default_option: "Backward"
                 Backward:
                     angles: [ 134.98885653282196 ]
                     average_secondary_flight_path: 0.671  # m
@@ -31,7 +31,7 @@ version:
                 function: "tosca_book"
                 citation: ""
                 parameters: *tfxa_constants
-                settings: *tfxa_settings
+                configurations: *tfxa_configurations
     TOSCA1:
         constants: &tosca1_constants
             final_neutron_energy: 32.0  # Final energy on the crystal analyser in cm-1
@@ -47,9 +47,9 @@ version:
             sample_width: 0.02  # m
             detector_width: 0.012  # m
             crystal_plane_spacing: 3.348e-10  # m
-        settings: &tosca1_settings
+        configurations: &tosca1_configurations
             detector_bank:
-                default_setting: "Backward"
+                default_option: "Backward"
                 Backward:
                     angles: [ 134.98885653282196 ]
                     average_secondary_flight_path: 0.7456  # m
@@ -62,7 +62,7 @@ version:
                 function: "tosca_book"
                 citation: ""
                 parameters: *tosca1_constants
-                settings: *tosca1_settings
+                configurations: *tosca1_configurations
     TOSCA:
         constants: &tosca_constants
             primary_flight_path: 17.  # m
@@ -70,13 +70,13 @@ version:
             sample_thickness: 0.002  # m
             detector_thickness: 0.0025  # m
             crystal_plane_spacing: 3.348e-10  # m
-        settings:
-            detector_bank: &tosca_settings
-                default_setting: "Backward"
-                Backward: &tosca_settings_backward
+        configurations:
+            detector_bank: &tosca_configurations
+                default_option: "Backward"
+                Backward: &tosca_configurations_backward
                     angles: [ 134.98885653282196 ]
                     average_bragg_angle_graphite: 47.73  # deg
-                Forward: &tosca_settings_forward
+                Forward: &tosca_configurations_forward
                     angles: [ 45.0 ]
                     average_bragg_angle_graphite: 47.45  # deg
 #            All detectors:
@@ -92,7 +92,7 @@ version:
                 #original_parameters: [2.5, 0.005, 0.0000001] wavenumber
                 parameters:
                     fit: [ 0.3099604960830007, 0.005, 8.065543937349209e-07 ]  # meV
-                settings: {}
+                configurations: {}
             book:
                 function: "tosca_book"
                 citation: ""
@@ -103,16 +103,16 @@ version:
                     graphite_thickness: 0.002  # m
                     sample_width: 0.04  # m ???????????? where is it used?
                     detector_width: 0.12  # m
-                settings:
+                configurations:
                     detector_bank:
-                        <<: *tosca_settings
+                        <<: *tosca_configurations
                         Backward:
-                            <<: *tosca_settings_backward
+                            <<: *tosca_configurations_backward
                             average_final_energy: 3.32  # meV
                             average_secondary_flight_path: 0.6279  # m
                             change_average_bragg_angle_graphite: 17.439366410966983
                         Forward:
-                            <<: *tosca_settings_forward
+                            <<: *tosca_configurations_forward
                             average_final_energy: 3.35  # meV
                             average_secondary_flight_path: 0.6279  # m
                             change_average_bragg_angle_graphite: 17.59374274222979
@@ -123,13 +123,13 @@ version:
                     <<: *tosca_constants
                     d_r: 12.9e-6
                     d_t: null
-                settings:
+                configurations:
                     detector_bank:
-                        <<: *tosca_settings
+                        <<: *tosca_configurations
                         Backward:
-                            <<: *tosca_settings_backward
+                            <<: *tosca_configurations_backward
                             distance_sample_analyzer: 0.23231778281139834  # m  0.5 * average_secondary_flight_path * np.sin(average_bragg_angle_graphite)
                         Forward:
-                            <<: *tosca_settings_forward
+                            <<: *tosca_configurations_forward
                             # TODO: Recompute below once average_secondary_flight_path for Forward has been recomputed
                             distance_sample_analyzer: 0.2312830382624369  # m (as above)

--- a/src/resolution_functions/instrument_data/vision.yaml
+++ b/src/resolution_functions/instrument_data/vision.yaml
@@ -21,4 +21,4 @@ version:
                     <<: *vision_constants
                     d_r: 11.6e-6
                     d_t: null
-                settings: {  }
+                configurations: {  }

--- a/src/resolution_functions/models/model_base.py
+++ b/src/resolution_functions/models/model_base.py
@@ -80,33 +80,33 @@ class ModelData(ABC):
     @property
     def restrictions(self) -> dict[str, list[int | float]]:
         """
-        The restrictions that the corresponding model places on each user-input argument.
+        The restrictions that the corresponding :term:`model` places on each :term:`setting`.
 
-        This is provided via a dictionary where the keys are the name of the user-input argument,
-        and the values are the restriction for that argument. The restrictions can be the upper or
-        lower bounds, or even a list of allowed values. If an invalid input is passed in, a
+        This is provided via a dictionary where the keys are the name of the :term:`setting`,
+        and the values are the restriction for that :term:`setting`. The restrictions can be the
+        upper or lower bounds, or even a list of allowed values. If an invalid input is passed in, a
         `InvalidInputError` will be raised.
 
         Returns
         -------
         restrictions
-            A mapping of user argument name to the corresponding restriction.
+            A mapping of :term:`setting` to its corresponding restriction.
         """
         return {}
 
     @property
     def defaults(self) -> dict[str, Any]:
         """
-        The defaults for each user-input argument for the corresponding model.
+        The defaults for each :term:`setting` for the corresponding :term:`model`.
 
-        This is provided as a dictionary where the keys are the name of the user-input argument,
-        and the values are the default for that argument. The default will be used when a particular
-        argument is not passed in.
+        This is provided as a dictionary where the keys are the name of the :term:`setting`,
+        and the values are the default for that :term:`setting`. The default will be used when a
+        particular :term:`setting` is not passed in to the :term:`model`
 
         Returns
         -------
         defaults
-            A mapping to user argument name to the corresponding default value.
+            A mapping of :term:`settings<setting>` to their corresponding default values.
         """
         return {}
 

--- a/src/resolution_functions/models/panther_abins.py
+++ b/src/resolution_functions/models/panther_abins.py
@@ -53,7 +53,7 @@ class PantherAbINSModel(InstrumentModel):
     output model being a Gaussian. This is done by fitting three power-series polynomials (see
     `numpy.polynomial.polynomial.Polynomial`) to the resolution curve, where the result of the sum
     of the polynomials is the width (sigma) of the Gaussian. Each polynomial can be of any degree
-    ane is given via the `resolution_functions.models.polynomial.PolynomialModelData`.
+    and is given via the `resolution_functions.models.polynomial.PolynomialModelData`.
 
     The :term:`resolution` is modelled as::
 
@@ -69,7 +69,7 @@ class PantherAbINSModel(InstrumentModel):
     model_data
         The data associated with the model for a given version of a given instrument.
     e_init
-        The initial energy in meV.
+        The incident energy in meV.
 
     Attributes
     ----------

--- a/src/resolution_functions/models/pychop.py
+++ b/src/resolution_functions/models/pychop.py
@@ -1299,7 +1299,7 @@ class PyChopModelCNCS(PyChopModelNonFermi):
     A PyChop :term:`model` for the CNCS :term:`instrument`.
 
     This :term:`model` is identical to all other PyChop models for instruments without a
-    :term:`Fermi chopper`, but the user-choice :term:`chopper` frequencies have unique names
+    :term:`Fermi chopper`, but the :term:`setting` ":term:`chopper` frequencies" have unique names
     compared to the other models.
 
     Parameters
@@ -1367,14 +1367,15 @@ class PyChopModelLET(PyChopModelNonFermi):
     A PyChop :term:`model` for the LET :term:`instrument`.
 
     This :term:`model` is identical to all other PyChop models for instruments without a
-    :term:`Fermi chopper`, but the user-choice :term:`chopper` frequencies have unique names
+    :term:`Fermi chopper`, but the :term:`setting` ":term:`chopper` frequencies" have unique names
     compared to the other models.
 
     The LET instrument, specifically, has a set-up with multiple choppers of variable frequency, but
     where some of the choppers are set to a pre-determined fraction of the frequency of another
-    chopper. Further, this relationship changes depending on the ``chopper_package`` setting. The
-    `PyChopModelDataNonFermi.frequency_matrix` attribute describes this relationship, and the
-    `get_long_frequency` method can be used to compute the frequencies of all choppers.
+    chopper. Further, this relationship changes depending on the ``chopper_package``
+    :term:`configuration`. The `PyChopModelDataNonFermi.frequency_matrix` attribute describes this
+    relationship, and the `get_long_frequency` method can be used to compute the frequencies of all
+    choppers.
 
     Parameters
     ----------

--- a/tests/integration_tests/test_lagrange.py
+++ b/tests/integration_tests/test_lagrange.py
@@ -11,7 +11,7 @@ from resolution_functions.instrument import Instrument
 
 WAVENUMBER_TO_MEV = 0.12398419843320028
 MEV_TO_WAVENUMBER = 1 / WAVENUMBER_TO_MEV
-LAGRANGE_SETTINGS = ['Cu(220)', 'Cu(331)', 'Si(311)', 'Si(111)']
+LAGRANGE_CONFIGURATIONS = ['Cu(220)', 'Cu(331)', 'Si(311)', 'Si(111)']
 
 
 @pytest.fixture(scope="module")
@@ -19,7 +19,7 @@ def lagrange_rf():
     return Instrument.from_default('Lagrange', 'Lagrange')
 
 
-@pytest.fixture(scope="module", params=LAGRANGE_SETTINGS)
+@pytest.fixture(scope="module", params=LAGRANGE_CONFIGURATIONS)
 def lagrange_abins_plus_rf_abins_resolution_function(lagrange_rf, request):
     abins = LagrangeInstrument(setting=request.param + ' (Lagrange)')
     rf = lagrange_rf.get_resolution_function('AbINS', monochromator=request.param)

--- a/tests/integration_tests/test_pychop.py
+++ b/tests/integration_tests/test_pychop.py
@@ -16,15 +16,15 @@ WAVENUMBER_TO_MEV = 0.12398419843320028
 MEV_TO_WAVENUMBER = 1 / WAVENUMBER_TO_MEV
 
 INSTRUMENTS = [[('MAPS', 'MAPS')], [('MARI', 'MARI')], [('MERLIN', 'MERLIN')]]
-INSTRUMENT_SETTINGS = [['A', 'S'], ['A', 'R', 'S'], ['S']]
+INSTRUMENT_CONFIGURATIONS = [['A', 'S'], ['A', 'R', 'S'], ['S']]
 ENERGIES = np.arange(50, 500, 10)
 CHOPPER_FREQUENCIES = np.arange(50, 601, 50)
 
 
-def get_instrument_matrix(instruments, instrument_settings):
+def get_instrument_matrix(instruments, instrument_configurations):
     instrument_matrix, instrument_ids = [], []
-    for instr, settings in zip(instruments, instrument_settings):
-        lst = list(itertools.product(instr, settings))
+    for instr, configs in zip(instruments, instrument_configurations):
+        lst = list(itertools.product(instr, configs))
         instrument_matrix.extend(lst)
         instrument_ids.extend([f'{i[0]}_{s}' for i, s in lst])
 
@@ -37,20 +37,20 @@ def get_ef_matrix(energies, chopper_frequencies):
     return ef_matrix, ef_ids
 
 
-def _abins_rf_2d(name, version, setting):
-    abins = PyChopInstrument(name=name, setting=setting)
+def _abins_rf_2d(name, version, config):
+    abins = PyChopInstrument(name=name, setting=config)
     rf = Instrument.from_default(name, version)
 
-    return abins, rf, setting
+    return abins, rf, config
 
 
-INSTRUMENT_MATRIX, INSTRUMENT_IDS = get_instrument_matrix(INSTRUMENTS, INSTRUMENT_SETTINGS)
+INSTRUMENT_MATRIX, INSTRUMENT_IDS = get_instrument_matrix(INSTRUMENTS, INSTRUMENT_CONFIGURATIONS)
 
 
 @pytest.fixture(scope="module", params=INSTRUMENT_MATRIX, ids=INSTRUMENT_IDS)
 def abins_rf_2d(request):
-    (name, version), setting = request.param
-    return _abins_rf_2d(name, version, setting)
+    (name, version), config = request.param
+    return _abins_rf_2d(name, version, config)
 
 
 EF_MATRIX, EF_IDS = get_ef_matrix(ENERGIES, CHOPPER_FREQUENCIES)
@@ -58,11 +58,11 @@ EF_MATRIX, EF_IDS = get_ef_matrix(ENERGIES, CHOPPER_FREQUENCIES)
 
 @pytest.mark.parametrize('matrix', EF_MATRIX, ids=EF_IDS)
 def test_against_abins(matrix, abins_rf_2d,):
-    abins, rf_2d, setting = abins_rf_2d
-    _test_against_abins(abins, rf_2d, setting, matrix)
+    abins, rf_2d, config = abins_rf_2d
+    _test_against_abins(abins, rf_2d, config, matrix)
 
 
-def _test_against_abins(abins, rf_2d, setting, matrix):
+def _test_against_abins(abins, rf_2d, config, matrix):
     energy, chopper_frequency = matrix
     frequencies = np.linspace(0, energy, 1000)
 
@@ -81,11 +81,14 @@ def _test_against_abins(abins, rf_2d, setting, matrix):
         except Warning:
             # Make sure this library agrees it is a no-transmission situation.
             with pytest.raises(NoTransmissionError):
-                rf_2d.get_resolution_function('PyChop_fit', chopper_package=setting, e_init=energy, chopper_frequency=chopper_frequency
+                rf_2d.get_resolution_function('PyChop_fit',
+                                              chopper_package=config,
+                                              e_init=energy,
+                                              chopper_frequency=chopper_frequency
 )
             return
 
-    rf = rf_2d.get_resolution_function('PyChop_fit', chopper_package=setting, e_init=energy,
+    rf = rf_2d.get_resolution_function('PyChop_fit', chopper_package=config, e_init=energy,
                                        chopper_frequency=chopper_frequency)
     actual = rf(frequencies)
     assert_allclose(actual, expected, rtol=1e-5)
@@ -95,8 +98,8 @@ def _test_against_abins(abins, rf_2d, setting, matrix):
                 params=[(('MARI', 'MARI'), 'G'), (('MERLIN', 'MERLIN'), 'G')],
                 ids=['MARI_G', 'MERLIN_G'])
 def g_choppers(request):
-    (name, version), setting = request.param
-    return _abins_rf_2d(name, version, setting)
+    (name, version), config = request.param
+    return _abins_rf_2d(name, version, config)
 
 
 ef, ids = get_ef_matrix(np.arange(10, 181, 5), CHOPPER_FREQUENCIES)
@@ -104,6 +107,6 @@ ef, ids = get_ef_matrix(np.arange(10, 181, 5), CHOPPER_FREQUENCIES)
 
 @pytest.mark.parametrize('matrix', ef, ids=ids)
 def test_g_choppers_against_abins(matrix, g_choppers,):
-    abins, rf_2d, setting = g_choppers
-    _test_against_abins(abins, rf_2d, setting, matrix)
+    abins, rf_2d, config = g_choppers
+    _test_against_abins(abins, rf_2d, config, matrix)
 

--- a/tests/unit_tests/test_pychop.py
+++ b/tests/unit_tests/test_pychop.py
@@ -63,7 +63,7 @@ INSTRUMENTS_FERMI = [
     [('SEQUOIA', 'SEQUOIA')],
 ]
 
-INSTRUMENT_SETTINGS_FERMI = [
+INSTRUMENT_CONFIGURATIONS_FERMI = [
     ['SEQ-100-2.0-AST', 'SEQ-700-3.5-AST', 'ARCS-100-1.5-AST', 'ARCS-700-1.5-AST',
      'ARCS-700-0.5-AST', 'ARCS-100-1.5-SMI', 'ARCS-700-1.5-SMI'],
     ['OnlyOne'],
@@ -76,8 +76,8 @@ INSTRUMENT_SETTINGS_FERMI = [
 
 INSTRUMENT_MATRIX_FERMI = list(
         itertools.chain.from_iterable(
-            itertools.product(instr, settings)
-                  for instr, settings in zip(INSTRUMENTS_FERMI, INSTRUMENT_SETTINGS_FERMI)
+            itertools.product(instr, configurations)
+                  for instr, configurations in zip(INSTRUMENTS_FERMI, INSTRUMENT_CONFIGURATIONS_FERMI)
         )
 )
 
@@ -85,22 +85,22 @@ INSTRUMENTS_NONFERMI = [
     [('CNCS', 'CNCS')],
     [('LET', 'LET')],
 ]
-INSTRUMENT_SETTINGS_NONFERMI = [
+INSTRUMENT_CONFIGURATIONS_NONFERMI = [
     ['High Flux', 'Intermediate', 'High Resolution'],
     ['High Flux', 'Intermediate', 'High Resolution'],
 ]
 INSTRUMENT_MATRIX_NONFERMI = list(
         itertools.chain.from_iterable(
-            itertools.product(instr, settings)
-                  for instr, settings in zip(INSTRUMENTS_NONFERMI, INSTRUMENT_SETTINGS_NONFERMI)
+            itertools.product(instr, configurations)
+                  for instr, configurations in zip(INSTRUMENTS_NONFERMI, INSTRUMENT_CONFIGURATIONS_NONFERMI)
         )
 )
 
 
 def instrument_id(matrix_row: tuple[tuple[str, str], str]) -> str:
-    """Get test id NAME_SETTING from input row ((NAME, NAME), SETTING)"""
-    (instrument, _), setting = matrix_row
-    return f"{instrument}_{setting}"
+    """Get test id NAME_configuration from input row ((NAME, NAME), configuration)"""
+    (instrument, _), configuration = matrix_row
+    return f"{instrument}_{configuration}"
 
 # id formatter for E_i input
 format_ei = "ei={}".format
@@ -112,21 +112,21 @@ def get_fake_frequencies(e_init: float) -> Float[np.ndarray]:
 
 @pytest.fixture(scope="module", params=INSTRUMENT_MATRIX_FERMI, ids=instrument_id)
 def pychop_fermi_data(request) -> tuple[PyChopModelDataFermi, PyChopInstrument]:
-    (name, version), setting = request.param
+    (name, version), configuration = request.param
     maps = Instrument.from_default(name, version)
-    rf = maps.get_model_data('PyChop_fit', chopper_package=setting)
+    rf = maps.get_model_data('PyChop_fit', chopper_package=configuration)
 
-    pc = PyChopInstrument(name, chopper=setting)
+    pc = PyChopInstrument(name, chopper=configuration)
     return rf, pc
 
 
 @pytest.fixture(scope="module", params=INSTRUMENT_MATRIX_NONFERMI, ids=instrument_id)
 def pychop_nonfermi_data(request) -> tuple[PyChopModelDataNonFermi, PyChopInstrument]:
-    (name, version), setting = request.param
+    (name, version), configuration = request.param
     maps = Instrument.from_default(name, version)
-    rf = maps.get_model_data('PyChop_fit', chopper_package=setting)
+    rf = maps.get_model_data('PyChop_fit', chopper_package=configuration)
 
-    pc = PyChopInstrument(name, chopper=setting)
+    pc = PyChopInstrument(name, chopper=configuration)
     return rf, pc
 
 
@@ -135,7 +135,7 @@ def mari_data():
     maps = Instrument.from_default('MARI', 'MARI')
     rf = maps.get_model_data('PyChop_fit')
 
-    pc = PyChopInstrument('MARI', chopper=maps.default_option_for_setting('PyChop_fit', 'chopper_package'))
+    pc = PyChopInstrument('MARI', chopper=maps.default_option_for_configuration('PyChop_fit', 'chopper_package'))
     return rf, pc
 
 


### PR DESCRIPTION
Resolves #8 

- [x] Rename the `settings` section in the YAML files `configurations`
- [x] Rename all the relevant methods on `Instrument`
- [x] Rewrite `Instrument` methods to work with the YAML renaming
- [x] Edit the docs of `Instrument.get_resolution_function` to reflect the distinction
- [x] Rename the `setting` entry in Glossary to `configuration`
- [x] Create a new Glossary entry for the new `setting` term
- [x] Update all documentation to reflect the changes made - both the RST files and the docstrings
