### PR TITLE
Add return annotation to get_model_signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ which model you want to use, as well as any model-specific parameters.
 ['AbINS', 'book', 'vision']
 >>> # There are multiple ways of querying the model-specific parameters, but the most comprehensive is
 >>> tosca.get_model_signature('book')
-<Signature (model_name: Optional[str] = 'book', *, detector_bank: Literal['Backward', 'Forward'] = 'Backward', _)>
+<Signature (model_name: Optional[str] = 'book', *, detector_bank: Literal['Backward', 'Forward'] = 'Backward', _) -> resolution_functions.models.tosca_book.ToscaBookModel>
 >>> # Now we can get the resolution function
 >>> book = tosca.get_resolution_function('book', detector_bank='Forward')
 >>> book

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -22,7 +22,7 @@ programmatically:
 >>> tosca.available_models
 ['AbINS', 'book', 'vision']
 >>> tosca.get_model_signature('book')
-<Signature (model_name: Optional[str] = 'book', *, detector_bank: Literal['Backward', 'Forward'] = 'Backward', _)>
+<Signature (model_name: Optional[str] = 'book', *, detector_bank: Literal['Backward', 'Forward'] = 'Backward', _) -> resolution_functions.models.tosca_book.ToscaBookModel>
 
 With this, it is possible to make the choices and obtain the resolution function
 via the

--- a/src/resolution_functions/instrument.py
+++ b/src/resolution_functions/instrument.py
@@ -555,7 +555,7 @@ class Instrument:
         >>> maps = Instrument.from_default('MAPS')
         >>> sig = maps.get_model_signature()
         >>> sig
-        <Signature (model_name: Optional[str] = 'PyChop_fit', *, chopper_package: Literal['A', 'B', 'S'] = 'A', e_init: Annotated[ForwardRef('Optional[float]'), 'restriction=[0, 2000]'] = 500, chopper_frequency: Annotated[ForwardRef('Optional[int]'), 'restriction=[50, 601, 50]'] = 400, fitting_order: 'Optional[int]' = 4, _)>
+        <Signature (model_name: Optional[str] = 'PyChop_fit', *, chopper_package: Literal['A', 'B', 'S'] = 'A', e_init: Annotated[ForwardRef('Optional[float]'), 'restriction=[0, 2000]'] = 500, chopper_frequency: Annotated[ForwardRef('Optional[int]'), 'restriction=[50, 601, 50]'] = 400, fitting_order: 'int' = 4, _) -> resolution_functions.models.pychop.PyChopModelFermi>
         >>> sig.parameters['e_init']
         <Parameter "e_init: Annotated[ForwardRef('Optional[float]'), 'restriction=[0, 2000]'] = 500">
         >>> sig.parameters['e_init'].kind

--- a/src/resolution_functions/instrument.py
+++ b/src/resolution_functions/instrument.py
@@ -602,7 +602,7 @@ class Instrument:
 
             params[key] = value.replace(**args, kind=Parameter.KEYWORD_ONLY)
 
-        return Signature(parameters=list(params.values()))
+        return Signature(parameters=list(params.values()), return_annotation=model_class)
 
     @property
     def available_models(self) -> list[str]:


### PR DESCRIPTION
The function `get_model_signature` is intended as a method for obtaining the call signature of `get_resolution_function`, and therefore its return annotation should be a subclass of `InstrumentModel`. Currently, the return annotation is `inspect._empty`, i.e. it is not set. This has been fixed.