### PR TITLE
Save citations as list

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ class and get the instrument object of your choice:
 
 ```
 >>> from resolution_functions import Instrument
->>> tosca = Instrument('TOSCA')
+>>> tosca = Instrument.from_default('TOSCA')
 >>> tosca
 Instrument(name='TOSCA', version='TOSCA', models=['AbINS', 'book', 'vision'])
 ```
@@ -36,8 +36,8 @@ which model you want to use, as well as any model-specific parameters.
 <Signature (model_name: Optional[str] = 'book', *, detector_bank: Literal['Backward', 'Forward'] = 'Backward', _)>
 >>> # Now we can get the resolution function
 >>> book = tosca.get_resolution_function('book', detector_bank='Forward')
->>> book
-<resolution_functions.models.tosca_book.ToscaBookModel object at 0x000000000>
+>>> print(book)
+ToscaBookModel(citation=[''])
 >>> book(100)
 0.81802604002035
 >>> import numpy as np

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -30,8 +30,8 @@ via the
 method:
 
 >>> book = tosca.get_resolution_function('book', detector_bank='Forward')
->>> book
-<resolution_functions.models.tosca_book.ToscaBookModel object at 0x000000000>
+>>> print(book)
+ToscaBookModel(citation=[''])
 
 .. note::
 

--- a/src/resolution_functions/instrument_data/arcs.yaml
+++ b/src/resolution_functions/instrument_data/arcs.yaml
@@ -76,7 +76,7 @@ version:
         models:
             PyChop_fit:
                 function: "pychop_fit_fermi"
-                citation: ""
+                citation: [""]
                 parameters:
                     <<: *constants
                 settings: *settings

--- a/src/resolution_functions/instrument_data/cncs.yaml
+++ b/src/resolution_functions/instrument_data/cncs.yaml
@@ -118,7 +118,7 @@ version:
         models:
             PyChop_fit:
                 function: "pychop_fit_cncs"
-                citation: ""
+                citation: [""]
                 parameters:
                     <<: *constants
                 settings: *settings

--- a/src/resolution_functions/instrument_data/hyspec.yaml
+++ b/src/resolution_functions/instrument_data/hyspec.yaml
@@ -83,7 +83,7 @@ version:
         models:
             PyChop_fit:
                 function: "pychop_fit_fermi"
-                citation: ""
+                citation: [""]
                 parameters:
                     <<: *constants
                 settings: *settings

--- a/src/resolution_functions/instrument_data/lagrange.yaml
+++ b/src/resolution_functions/instrument_data/lagrange.yaml
@@ -30,6 +30,6 @@ version:
         models:
             AbINS:
                 function: "discontinuous_polynomial"
-                citation: ""
+                citation: [""]
                 parameters: {}
                 settings: *lagrange_settings

--- a/src/resolution_functions/instrument_data/let.yaml
+++ b/src/resolution_functions/instrument_data/let.yaml
@@ -117,7 +117,7 @@ version:
         models:
             PyChop_fit:
                 function: "pychop_fit_let"
-                citation: ""
+                citation: [""]
                 parameters:
                     <<: *constants
                 settings: *settings

--- a/src/resolution_functions/instrument_data/maps.yaml
+++ b/src/resolution_functions/instrument_data/maps.yaml
@@ -68,7 +68,7 @@ version:
         models:
             PyChop_fit:
                 function: "pychop_fit_fermi"
-                citation: ""
+                citation: [""]
                 parameters:
                     <<: *maps_constants
                 settings: *maps_settings

--- a/src/resolution_functions/instrument_data/mari.yaml
+++ b/src/resolution_functions/instrument_data/mari.yaml
@@ -87,7 +87,7 @@ version:
         models:
             PyChop_fit:
                 function: "pychop_fit_fermi"
-                citation: ""
+                citation: [""]
                 parameters:
                     <<: *mari_constants
                 settings: *mari_settings

--- a/src/resolution_functions/instrument_data/merlin.yaml
+++ b/src/resolution_functions/instrument_data/merlin.yaml
@@ -63,7 +63,7 @@ version:
         models:
             PyChop_fit:
                 function: "pychop_fit_fermi"
-                citation: ""
+                citation: [""]
                 parameters:
                     <<: *constants
                 settings: *settings

--- a/src/resolution_functions/instrument_data/panther.yaml
+++ b/src/resolution_functions/instrument_data/panther.yaml
@@ -14,7 +14,7 @@ version:
                 # sigma = polyval(abs_meV, ɛ) + polyval(ei_dependence, E_i) + polyval(ei_energy_product, E_i × ɛ)
                 # (Here a quartic polynomial in ɛ, plus quadratic on Ei and cubic on ɛ×Ei)
                 function: "panther_abins_polynomial"
-                citation: ""
+                citation: [""]
                 settings: {}
                 parameters:
                     abs:

--- a/src/resolution_functions/instrument_data/sequoia.yaml
+++ b/src/resolution_functions/instrument_data/sequoia.yaml
@@ -84,7 +84,7 @@ version:
         models:
             PyChop_fit:
                 function: "pychop_fit_fermi"
-                citation: ""
+                citation: [""]
                 parameters:
                     <<: *constants
                 settings: *settings

--- a/src/resolution_functions/instrument_data/tosca.yaml
+++ b/src/resolution_functions/instrument_data/tosca.yaml
@@ -29,7 +29,7 @@ version:
         models:
             book:
                 function: "tosca_book"
-                citation: ""
+                citation: [""]
                 parameters: *tfxa_constants
                 settings: *tfxa_settings
     TOSCA1:
@@ -60,7 +60,7 @@ version:
         models:
             book:
                 function: "tosca_book"
-                citation: ""
+                citation: [""]
                 parameters: *tosca1_constants
                 settings: *tosca1_settings
     TOSCA:
@@ -88,14 +88,14 @@ version:
                 # sigma = tosca_a * omega * omega + tosca_b * omega + tosca_c
                 # where sigma is width of Gaussian function
                 function: "polynomial_1d"
-                citation: ""
+                citation: [""]
                 #original_parameters: [2.5, 0.005, 0.0000001] wavenumber
                 parameters:
                     fit: [ 0.3099604960830007, 0.005, 8.065543937349209e-07 ]  # meV
                 settings: {}
             book:
                 function: "tosca_book"
-                citation: ""
+                citation: [""]
                 parameters:
                     <<: *tosca_constants
                     water_moderator_constant: 44  # us
@@ -118,7 +118,7 @@ version:
                             change_average_bragg_angle_graphite: 17.59374274222979
             vision:
                 function: "vision_paper"
-                citation: "https://doi.org/10.1016/j.nima.2009.03.204"
+                citation: ["https://doi.org/10.1016/j.nima.2009.03.204"]
                 parameters:
                     <<: *tosca_constants
                     d_r: 12.9e-6

--- a/src/resolution_functions/instrument_data/vision.yaml
+++ b/src/resolution_functions/instrument_data/vision.yaml
@@ -16,7 +16,7 @@ version:
         models:
             vision:
                 function: "vision_paper"
-                citation: "https://doi.org/10.1016/j.nima.2009.03.204"
+                citation: ["https://doi.org/10.1016/j.nima.2009.03.204"]
                 parameters:
                     <<: *vision_constants
                     d_r: 11.6e-6

--- a/src/resolution_functions/models/model_base.py
+++ b/src/resolution_functions/models/model_base.py
@@ -75,7 +75,7 @@ class ModelData(ABC):
     defaults
     """
     function: str
-    citation: str
+    citation: list[str]
 
     @property
     def restrictions(self) -> dict[str, list[int | float]]:
@@ -174,10 +174,10 @@ class InstrumentModel(ABC):
         raise NotImplementedError()
 
     def __str__(self) -> str:
-        return f'{type(self).__name__}(citation="{self.citation}")'
+        return f'{type(self).__name__}(citation={self.citation})'
 
     @property
-    def citation(self) -> str:
+    def citation(self) -> list[str]:
         """
         The citation for this model. Please use this to look up more details and cite the model.
 


### PR DESCRIPTION
Any given model can have multiple citations, which is difficult to do in a single string - a list of strings is better for that purpose.