### PR TITLE
Add new PyChop version and create model versioning

### DIFF
--- a/src/resolution_functions/instrument.py
+++ b/src/resolution_functions/instrument.py
@@ -643,8 +643,26 @@ class Instrument:
     @property
     def available_models(self) -> list[str]:
         """
+        A list of :term:`models<model>` available for this :term:`version` of this
+        :term:`instrument`.
+
+        Only includes the recommended version of each model - does not list all versions of all
+        models.
+
+        Returns
+        -------
+        available_models
+            A list of available models.
+        """
+        return [name for name, value in self._models.items() if isinstance(value, str)]
+
+    @property
+    def all_available_models(self) -> list[str]:
+        """
         A list of all :term:`models<model>` available for this :term:`version` of this
         :term:`instrument`.
+
+        Includes both all the versions of all models and
 
         Returns
         -------
@@ -652,6 +670,22 @@ class Instrument:
             A list of all available models.
         """
         return list(self._models.keys())
+
+    @property
+    def available_unique_models(self) -> list[str]:
+        """
+        A list of all unique :term:`models<model>` available for this :term:`version` of this
+        :term:`instrument`.
+
+        Only includes the versioned models, i.e. lists all versions of all models, but does not list
+        the recommended models.
+
+        Returns
+        -------
+        available_models
+            A list of all available unique models.
+        """
+        return [name for name, value in self._models.items() if not isinstance(value, str)]
 
     @property
     def available_models_and_configurations(self) -> dict[str, list[str]]:

--- a/src/resolution_functions/instrument.py
+++ b/src/resolution_functions/instrument.py
@@ -667,8 +667,8 @@ class Instrument:
         models_and_configurations
             All models and all their configurations.
         """
-        return {model_name: list(model['configurations'].keys())
-                for model_name, model in self._models.items()}
+        return {model_name: list(self._resolve_model(model_name)['configurations'].keys())
+                for model_name in self._models.keys()}
 
     @property
     def all_available_models_options(self) -> dict[str, dict[str, list[str]]]:
@@ -686,8 +686,8 @@ class Instrument:
             All models, all their configurations, and all their options.
         """
         return {model_name: {config: self._get_options(value)
-                             for config, value in list(model['configurations'].items())}
-                for model_name, model in self._models.items()}
+                for config, value in list(self._resolve_model(model_name)['configurations'].items())}
+                for model_name in self._models.keys()}
 
     def possible_configurations_for_model(self, model_name: str) -> list[str]:
         """

--- a/src/resolution_functions/instrument.py
+++ b/src/resolution_functions/instrument.py
@@ -430,7 +430,7 @@ class Instrument:
         if model_name is None:
             model_name = self.default_model
 
-        model = self._resolve_model(model_name)
+        model, model_name = self._resolve_model(model_name)
 
         available_configurations = model['configurations']
 
@@ -448,7 +448,7 @@ class Instrument:
                                        **ChainMap(*configurations, model['parameters']))
         return model, model_name
 
-    def _resolve_model(self, model_name: str) -> dict:
+    def _resolve_model(self, model_name: str) -> tuple[dict, str]:
         """
         Returns the data for the `model_name` model, taking into account aliases.
 
@@ -468,12 +468,13 @@ class Instrument:
             raise InvalidModelError(model_name, self)
 
         if isinstance(model, str):
+            model_name = model
             try:
                 model = self._models[model]
             except KeyError:
                 raise InvalidModelError(model, self)
 
-        return model
+        return model, model_name
 
     def get_resolution_function(self, model_name: Optional[str] = None, **kwargs) -> InstrumentModel:
         """
@@ -813,7 +814,7 @@ class Instrument:
         InvalidModelError
             If the provided `model_name` is not supported for this version of this instrument.
         """
-        return list(self._resolve_model(model_name)['configurations'])
+        return list(self._resolve_model(model_name)[0]['configurations'])
 
     def possible_options_for_model(self, model_name: str) -> dict[str, list[str]]:
         """
@@ -836,7 +837,7 @@ class Instrument:
         InvalidModelError
             If the provided `model_name` is not supported for this version of this instrument.
         """
-        model = self._resolve_model(model_name)
+        model, _ = self._resolve_model(model_name)
 
         return {config: self._get_options(value)
                 for config, value in model['configurations'].items()}
@@ -868,7 +869,7 @@ class Instrument:
             If the provided `configuration` is not supported for the `model_name` model of this
             instrument.
         """
-        configurations = self._resolve_model(model_name)['configurations']
+        configurations = self._resolve_model(model_name)[0]['configurations']
 
         try:
             configurations = configurations[configuration]
@@ -924,7 +925,7 @@ class Instrument:
             If the provided `configuration` is not supported for the `model_name` model of this
             instrument.
         """
-        configurations = self._resolve_model(model_name)['configurations']
+        configurations = self._resolve_model(model_name)[0]['configurations']
 
         try:
             configurations = configurations[configuration]

--- a/src/resolution_functions/instrument.py
+++ b/src/resolution_functions/instrument.py
@@ -703,7 +703,7 @@ class Instrument:
             A string containing the nicely formatted table.
         """
         contents = [['MODEL', 'ALIAS FOR', 'CONFIGURATIONS']]
-        longest_name, longest_alias, longest_config = 5, 9, 14
+        longest_name, longest_alias, longest_config = map(len, contents[0])
 
         for model_name, model_data in self._models.items():
             length = len(model_name)
@@ -745,7 +745,7 @@ class Instrument:
             A string containing the nicely formatted table.
         """
         contents = [['MODEL', 'ALIAS FOR', 'CONFIGURATIONS', 'OPTIONS']]
-        longest_name, longest_alias, longest_config, longest_option = 5, 9, 14, 7
+        longest_name, longest_alias, longest_config, longest_option = map(len, contents[0])
 
         for model_name, model_data in self._models.items():
             length = len(model_name)

--- a/src/resolution_functions/instrument.py
+++ b/src/resolution_functions/instrument.py
@@ -665,7 +665,8 @@ class Instrument:
         A list of all :term:`models<model>` available for this :term:`version` of this
         :term:`instrument`.
 
-        Includes both all the versions of all models and
+        Includes both all the versions of all models (see `Instrument.available_unique_models` and
+        the recommended versions (see `Instrument.available_models`).
 
         Returns
         -------

--- a/src/resolution_functions/instrument.py
+++ b/src/resolution_functions/instrument.py
@@ -157,7 +157,7 @@ class Instrument:
         instrument_list
             A list of names of INS instruments supported by this library.
         """
-        return list(INSTRUMENT_MAP.keys())
+        return list(INSTRUMENT_MAP)
 
     @classmethod
     def _available_versions(cls, path: str) -> tuple[list[str], str]:
@@ -183,7 +183,7 @@ class Instrument:
         with open(path, 'r') as f:
             data = yaml.safe_load(f)
 
-        return list(data['version'].keys()), data['default_version']
+        return list(data['version']), data['default_version']
 
     @classmethod
     def available_versions(cls, instrument_name: str) -> tuple[list[str], str]:
@@ -268,7 +268,7 @@ class Instrument:
         try:
             version_data = version_data[version]
         except KeyError:
-            versions = list(version_data.keys())
+            versions = list(version_data)
             raise InvalidVersionError(f'"{version}" is not a valid version name. Only the following'
                                       f' versions are supported for this instrument: {versions}')
 
@@ -357,7 +357,7 @@ class Instrument:
         except KeyError:
             raise InvalidInstrumentError(
                 f'"{instrument_name}" is not a valid instrument name. Only the following instruments are '
-                f'supported: {list(INSTRUMENT_MAP.keys())}')
+                f'supported: {list(INSTRUMENT_MAP)}')
 
         return os.path.join(INSTRUMENT_DATA_PATH, file_name + '.yaml'), implied_version
 
@@ -671,7 +671,7 @@ class Instrument:
         available_models
             A list of all available models.
         """
-        return list(self._models.keys())
+        return list(self._models)
 
     @property
     def available_unique_models(self) -> list[str]:
@@ -813,7 +813,7 @@ class Instrument:
         InvalidModelError
             If the provided `model_name` is not supported for this version of this instrument.
         """
-        return list(self._resolve_model(model_name)['configurations'].keys())
+        return list(self._resolve_model(model_name)['configurations'])
 
     def possible_options_for_model(self, model_name: str) -> dict[str, list[str]]:
         """
@@ -897,7 +897,7 @@ class Instrument:
         options
             A list of options as found in the provided `configuration` dictionary.
         """
-        return [value for value in configuration.keys() if value != 'default_option']
+        return [value for value in configuration if value != 'default_option']
 
     def default_option_for_configuration(self, model_name: str, configuration: str) -> str:
         """

--- a/src/resolution_functions/instrument.py
+++ b/src/resolution_functions/instrument.py
@@ -710,11 +710,10 @@ class Instrument:
             if isinstance(model_data, str):
                 contents.append([model_name, model_data, ''])
             else:
-                for i, config_name in enumerate(model_data['configurations']):
-                    if i == 0:
-                        contents.append([model_name, '', config_name])
-                    else:
-                        contents.append(['', '', config_name])
+                tmp = [['', '', config_name]
+                       for config_name in model_data['configurations']]
+                tmp[0][0] = model_name
+                contents.extend(tmp)
 
         return _format_table(contents)
 
@@ -956,8 +955,8 @@ def _split_on_model(contents: np.ndarray) -> Iterator[list[list[str]]]:
     contents
         The 2D contents of the table.
 
-    Returns
-    -------
+    Yields
+    ------
     group
         A subset of the table, in which the first cell is occupied.
     """

--- a/src/resolution_functions/instrument.py
+++ b/src/resolution_functions/instrument.py
@@ -616,7 +616,7 @@ class Instrument:
                                     annotation=Optional[str])
         }
 
-        for configuration_name, options in model_data['configurations'].items():
+        for configuration_name, options in self._models[model_name]['configurations'].items():
             option_names = self._get_options(options)
             params[configuration_name] = Parameter(configuration_name,
                                                    Parameter.KEYWORD_ONLY,

--- a/src/resolution_functions/instrument_data/arcs.yaml
+++ b/src/resolution_functions/instrument_data/arcs.yaml
@@ -34,7 +34,7 @@ version:
                     distance: 11.61  # m
                     aperture_distance: 9.342  # m
         configurations:
-            chopper_package: &configurations
+            chopper_package: &chopper_package
                 default_option: 'ARCS-100-1.5-AST'
                 SEQ-100-2.0-AST:
                     pslit: 2.03e-3  # m
@@ -74,7 +74,7 @@ version:
                         parameters: [ 119.63, 33.618, .037, .17, 172.42 ]      # Parameters for time profile
                 configurations:
                     chopper_package:
-                        <<: *configurations
+                        <<: *chopper_package
                         ARCS-100-1.5-SMI:
                             pslit: 1.52e-3  # m
                             radius: 50.0e-3  # m
@@ -95,7 +95,7 @@ version:
                         parameters: [281., 79.0, .087, .4, 172.]     # Parameters for time profile
                 configurations:
                     chopper_package:
-                        <<: *configurations
+                        <<: *chopper_package
                         ARCS-100-1.5-SMI:
                             pslit: 1.5e-3  # m
                             radius: 50.0e-3  # m

--- a/src/resolution_functions/instrument_data/arcs.yaml
+++ b/src/resolution_functions/instrument_data/arcs.yaml
@@ -13,13 +13,12 @@ version:
             default_chopper_frequency: 300
             allowed_chopper_frequencies: [60, 601, 60]
             frequency_matrix: [[1]]
-            moderator:
+            moderator: &moderator
                 type: 1
                 scaling_function: null
                 scaling_parameters: null
                 measured_wavelength: null
                 measured_width: null
-                parameters: [119.63, 33.618, .037, .17, 172.42]      # Parameters for time profile
             detector:
                 type: 2
                 phi: 0.0
@@ -34,8 +33,8 @@ version:
                 Fermi:
                     distance: 11.61  # m
                     aperture_distance: 9.342  # m
-        configurations: &configurations
-            chopper_package:
+        configurations:
+            chopper_package: &configurations
                 default_option: 'ARCS-100-1.5-AST'
                 SEQ-100-2.0-AST:
                     pslit: 2.03e-3  # m
@@ -62,22 +61,48 @@ version:
                     radius: 50.0e-3  # m
                     rho: 1.5350  # m
                     tjit: 0.0             # Jitter time (us)
-                ARCS-100-1.5-SMI:
-                    pslit: 1.52e-3  # m
-                    radius: 50.0e-3  # m
-                    rho: 0.5800  # m
-                    tjit: 0.0             # Jitter time (us)
-                ARCS-700-1.5-SMI:
-                    pslit: 1.52e-3  # m
-                    radius: 50.0e-3  # m
-                    rho: 1.5350  # m
-                    tjit: 0.0             # Jitter time (us)
         default_model: 'PyChop_fit'
         models:
-            PyChop_fit: "PyChop_fit_v1"
+            PyChop_fit: "PyChop_fit_v2"
             PyChop_fit_v1:
                 function: "pychop_fit_fermi"
                 citation: [""]
                 parameters:
                     <<: *constants
-                configurations: *configurations
+                    moderator:
+                        <<: *moderator
+                        parameters: [ 119.63, 33.618, .037, .17, 172.42 ]      # Parameters for time profile
+                configurations:
+                    chopper_package:
+                        <<: *configurations
+                        ARCS-100-1.5-SMI:
+                            pslit: 1.52e-3  # m
+                            radius: 50.0e-3  # m
+                            rho: 0.5800  # m
+                            tjit: 0.0             # Jitter time (us)
+                        ARCS-700-1.5-SMI:
+                            pslit: 1.52e-3  # m
+                            radius: 50.0e-3  # m
+                            rho: 1.5350  # m
+                            tjit: 0.0             # Jitter time (us)
+            PyChop_fit_v2:
+                function: "pychop_fit_fermi"
+                citation: [ "" ]
+                parameters:
+                    <<: *constants
+                    moderator:
+                        <<: *moderator
+                        parameters: [281., 79.0, .087, .4, 172.]     # Parameters for time profile
+                configurations:
+                    chopper_package:
+                        <<: *configurations
+                        ARCS-100-1.5-SMI:
+                            pslit: 1.5e-3  # m
+                            radius: 50.0e-3  # m
+                            rho: 0.6400  # m
+                            tjit: 0.0             # Jitter time (us)
+                        ARCS-700-1.5-SMI:
+                            pslit: 1.5e-3  # m
+                            radius: 50.0e-3  # m
+                            rho: 1.5350  # m
+                            tjit: 0.0             # Jitter time (us)

--- a/src/resolution_functions/instrument_data/arcs.yaml
+++ b/src/resolution_functions/instrument_data/arcs.yaml
@@ -74,7 +74,8 @@ version:
                     tjit: 0.0             # Jitter time (us)
         default_model: 'PyChop_fit'
         models:
-            PyChop_fit:
+            PyChop_fit: "PyChop_fit_v1"
+            PyChop_fit_v1:
                 function: "pychop_fit_fermi"
                 citation: [""]
                 parameters:

--- a/src/resolution_functions/instrument_data/cncs.yaml
+++ b/src/resolution_functions/instrument_data/cncs.yaml
@@ -116,7 +116,8 @@ version:
                             slot_width: 9.86
         default_model: 'PyChop_fit'
         models:
-            PyChop_fit:
+            PyChop_fit: "PyChop_fit_v1"
+            PyChop_fit_v1:
                 function: "pychop_fit_cncs"
                 citation: [""]
                 parameters:

--- a/src/resolution_functions/instrument_data/hyspec.yaml
+++ b/src/resolution_functions/instrument_data/hyspec.yaml
@@ -81,7 +81,8 @@ version:
                     tjit: 0.0
         default_model: 'PyChop_fit'
         models:
-            PyChop_fit:
+            PyChop_fit: "PyChop_fit_v1"
+            PyChop_fit_v1:
                 function: "pychop_fit_fermi"
                 citation: [""]
                 parameters:

--- a/src/resolution_functions/instrument_data/lagrange.yaml
+++ b/src/resolution_functions/instrument_data/lagrange.yaml
@@ -28,7 +28,8 @@ version:
                     fit: [0.8]  # meV
         default_model: "AbINS"
         models:
-            AbINS:
+            AbINS: "AbINS_v1"
+            AbINS_v1:
                 function: "discontinuous_polynomial"
                 citation: [""]
                 parameters: {}

--- a/src/resolution_functions/instrument_data/let.yaml
+++ b/src/resolution_functions/instrument_data/let.yaml
@@ -115,7 +115,8 @@ version:
                             slot_width: 15
         default_model: 'PyChop_fit'
         models:
-            PyChop_fit:
+            PyChop_fit: "PyChop_fit_v1"
+            PyChop_fit_v1:
                 function: "pychop_fit_let"
                 citation: [""]
                 parameters:

--- a/src/resolution_functions/instrument_data/maps.yaml
+++ b/src/resolution_functions/instrument_data/maps.yaml
@@ -66,7 +66,8 @@ version:
                     tjit: 0.0             # Jitter time (us)
         default_model: 'PyChop_fit'
         models:
-            PyChop_fit:
+            PyChop_fit: "PyChop_fit_v1"
+            PyChop_fit_v1:
                 function: "pychop_fit_fermi"
                 citation: [""]
                 parameters:

--- a/src/resolution_functions/instrument_data/mari.yaml
+++ b/src/resolution_functions/instrument_data/mari.yaml
@@ -85,7 +85,8 @@ version:
                     allowed_e_init: [ 0, 2000 ]  # meV
         default_model: 'PyChop_fit'
         models:
-            PyChop_fit:
+            PyChop_fit: "PyChop_fit_v1"
+            PyChop_fit_v1:
                 function: "pychop_fit_fermi"
                 citation: [""]
                 parameters:

--- a/src/resolution_functions/instrument_data/merlin.yaml
+++ b/src/resolution_functions/instrument_data/merlin.yaml
@@ -61,7 +61,8 @@ version:
                     allowed_e_init: [ 7, 2000 ]  # meV
         default_model: 'PyChop_fit'
         models:
-            PyChop_fit:
+            PyChop_fit: "PyChop_fit_v1"
+            PyChop_fit_v1:
                 function: "pychop_fit_fermi"
                 citation: [""]
                 parameters:

--- a/src/resolution_functions/instrument_data/panther.yaml
+++ b/src/resolution_functions/instrument_data/panther.yaml
@@ -9,13 +9,13 @@ version:
         configurations: {}
         default_model: "AbINS"
         models:
-            AbINS:
+            AbINS: "AbINS_v1"
+            AbINS_v1:
                 # Resolution function fitted to incident energy and energy transfer:
                 # sigma = polyval(abs_meV, ɛ) + polyval(ei_dependence, E_i) + polyval(ei_energy_product, E_i × ɛ)
                 # (Here a quartic polynomial in ɛ, plus quadratic on Ei and cubic on ɛ×Ei)
                 function: "panther_abins_polynomial"
                 citation: [""]
-                citation: ""
                 configurations: {}
                 parameters:
                     abs:

--- a/src/resolution_functions/instrument_data/sequoia.yaml
+++ b/src/resolution_functions/instrument_data/sequoia.yaml
@@ -82,7 +82,8 @@ version:
                     tjit: 0.0             # Jitter time (us)
         default_model: 'PyChop_fit'
         models:
-            PyChop_fit:
+            PyChop_fit: "PyChop_fit_v1"
+            PyChop_fit_v1:
                 function: "pychop_fit_fermi"
                 citation: [""]
                 parameters:

--- a/src/resolution_functions/instrument_data/sequoia.yaml
+++ b/src/resolution_functions/instrument_data/sequoia.yaml
@@ -13,18 +13,15 @@ version:
             default_chopper_frequency: 300
             allowed_chopper_frequencies: [60, 601, 60]
             frequency_matrix: [[1]]
-            moderator:
+            moderator: &moderator
                 type: 1
                 scaling_function: null
                 measured_wavelength: null
-                parameters: [119.63, 33.618, .037, .17, 172.42]      # Parameters for time profile
             detector:
                 type: 2
                 phi: 0.0
                 depth: 0.025  # Detector depth (m)
-            sample:
-                type: 0  # Sample type: 0==flat plate, 1==ellipse, 2==annulus, 3==sphere, 4==solid cylinder
-                thickness: 2.0e-3  # Thickness (m)
+            sample: &sample
                 width: 4.8e-2  # Width (m)
                 height: 4.8e-2  # Height (m)
                 gamma: 0.0  # Angle of x-axis to ki (degrees)
@@ -32,28 +29,13 @@ version:
                 Fermi:
                     distance: 18.01  # m
                     aperture_distance: 17.0  # m
-        configurations: &configurations
-            chopper_package:
+        configurations:
+            chopper_package: &configurations
                 default_option: 'ARCS-100-1.5-AST'
-                Fine:
-                    pslit: 1.087e-3  # m
-                    radius: 49.0e-3  # m
-                    rho: 1.300  # m
-                    tjit: 0.0             # Jitter time (us)
-                Sloppy:
-                    pslit: 1.812e-3  # m
-                    radius: 49.0e-3  # m
-                    rho: 0.92  # m
-                    tjit: 0.0             # Jitter time (us)
                 SEQ-100-2.0-AST:
                     pslit: 2.03e-3  # m
                     radius: 50.0e-3  # m
                     rho: 0.5800  # m
-                    tjit: 0.0             # Jitter time (us)
-                SEQ-700-3.5-AST:
-                    pslit: 3.56e-3  # m
-                    radius: 50.0e-3  # m
-                    rho: 1.5350  # m
                     tjit: 0.0             # Jitter time (us)
                 ARCS-100-1.5-AST:
                     pslit: 1.52e-3  # m
@@ -82,10 +64,64 @@ version:
                     tjit: 0.0             # Jitter time (us)
         default_model: 'PyChop_fit'
         models:
-            PyChop_fit: "PyChop_fit_v1"
+            PyChop_fit: "PyChop_fit_v2"
             PyChop_fit_v1:
                 function: "pychop_fit_fermi"
                 citation: [""]
                 parameters:
                     <<: *constants
-                configurations: *configurations
+                    moderator:
+                        <<: *moderator
+                        parameters: [ 119.63, 33.618, .037, .17, 172.42 ]      # Parameters for time profile
+                    sample:
+                        <<: *sample
+                        type: 0  # Sample type: 0==flat plate, 1==ellipse, 2==annulus, 3==sphere, 4==solid cylinder
+                        thickness: 2.0e-3  # Thickness (m)
+                configurations:
+                    chopper_package:
+                        <<: *configurations
+                        Fine:
+                            pslit: 1.087e-3  # m
+                            radius: 49.0e-3  # m
+                            rho: 1.300  # m
+                            tjit: 0.0             # Jitter time (us)
+                        Sloppy:
+                            pslit: 1.812e-3  # m
+                            radius: 49.0e-3  # m
+                            rho: 0.92  # m
+                            tjit: 0.0             # Jitter time (us)
+                        SEQ-700-3.5-AST:
+                            pslit: 3.56e-3  # m
+                            radius: 50.0e-3  # m
+                            rho: 1.5350  # m
+                            tjit: 0.0             # Jitter time (us)
+            PyChop_fit_v2:
+                function: "pychop_fit_fermi"
+                citation: [""]
+                parameters:
+                    <<: *constants
+                    moderator:
+                        <<: *moderator
+                        parameters: [30.13, 10.0, .07, .08, 50.42]    # Parameters for time profile
+                    sample:
+                        <<: *sample
+                        type: 2  # Sample type: 0==flat plate, 1==ellipse, 2==annulus, 3==sphere, 4==solid cylinder
+                        thickness: 4.8e-2  # Thickness (m)
+                configurations:
+                    chopper_package:
+                        <<: *configurations
+                        High-Resolution:
+                            pslit: 2.03e-3  # m
+                            radius: 50.0e-3  # m
+                            rho: 0.580  # m
+                            tjit: 0.0             # Jitter time (us)
+                        High-Flux:
+                            pslit: 4.56e-3  # m
+                            radius: 50.0e-3  # m
+                            rho: 1.535  # m
+                            tjit: 0.0             # Jitter time (us)
+                        SEQ-700-3.5-AST:
+                            pslit: 4.56e-3  # m
+                            radius: 50.0e-3  # m
+                            rho: 1.5350  # m
+                            tjit: 0.0             # Jitter time (us)

--- a/src/resolution_functions/instrument_data/tosca.yaml
+++ b/src/resolution_functions/instrument_data/tosca.yaml
@@ -27,7 +27,8 @@ version:
                     average_bragg_angle_graphite: 43.  # deg
         default_model: "book"
         models:
-            book:
+            book: "book_v1"
+            book_v1:
                 function: "tosca_book"
                 citation: [""]
                 parameters: *tfxa_constants
@@ -58,7 +59,8 @@ version:
                     change_average_bragg_angle_graphite: 5.0814852427945665
         default_model: "book"
         models:
-            book:
+            book: "book_v1"
+            book_v1:
                 function: "tosca_book"
                 citation: [""]
                 parameters: *tosca1_constants
@@ -83,7 +85,8 @@ version:
 #                angles: [ 45.0, 134.98885653282196 ]
         default_model: "AbINS"
         models:
-            AbINS:
+            AbINS: "AbINS_v1"
+            AbINS_v1:
                 # TOSCA parameters for resolution function
                 # sigma = tosca_a * omega * omega + tosca_b * omega + tosca_c
                 # where sigma is width of Gaussian function
@@ -93,7 +96,8 @@ version:
                 parameters:
                     fit: [ 0.3099604960830007, 0.005, 8.065543937349209e-07 ]  # meV
                 configurations: {}
-            book:
+            book: "book_v1"
+            book_v1:
                 function: "tosca_book"
                 citation: [""]
                 parameters:
@@ -116,7 +120,8 @@ version:
                             average_final_energy: 3.35  # meV
                             average_secondary_flight_path: 0.6279  # m
                             change_average_bragg_angle_graphite: 17.59374274222979
-            vision:
+            vision: "vision_v1"
+            vision_v1:
                 function: "vision_paper"
                 citation: ["https://doi.org/10.1016/j.nima.2009.03.204"]
                 parameters:

--- a/src/resolution_functions/instrument_data/vision.yaml
+++ b/src/resolution_functions/instrument_data/vision.yaml
@@ -14,7 +14,8 @@ version:
             average_bragg_angle_graphite: 45.  # deg
         default_model: "vision"
         models:
-            vision:
+            vision: "vision_v1"
+            vision_v1:
                 function: "vision_paper"
                 citation: ["https://doi.org/10.1016/j.nima.2009.03.204"]
                 parameters:


### PR DESCRIPTION
Resolves the PyChop issue documented at [Mantid#38591](https://github.com/mantidproject/mantid/pull/38591)

Simultaneously, applies new versioning scheme for models, where all models are versioned with `_v{int}` at the end of their names to keep record of model changes, and aliases are created without the version to provide seamless access to the latest version of models.
