### PR TITLE
Add PANTHER tests

### DIFF
--- a/tests/integration_tests/test_panther.py
+++ b/tests/integration_tests/test_panther.py
@@ -1,0 +1,37 @@
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+
+import mantid
+from abins.instruments.panther import PantherInstrument
+
+from resolution_functions.instrument import Instrument
+
+
+WAVENUMBER_TO_MEV = 0.12398419843320028
+MEV_TO_WAVENUMBER = 8.06554465
+
+
+@pytest.fixture(scope="module")
+def panther_rf():
+    return Instrument.from_default('PANTHER', 'PANTHER')
+
+
+@pytest.fixture(scope="module", params=np.arange(0, 1209, 20), ids=lambda e: f'ei={e}')
+def panther_abins_plus_rf_abins_resolution_function(panther_rf, request):
+    abins = PantherInstrument()
+    abins.set_incident_energy(request.param, 'meV')
+
+    rf = panther_rf.get_resolution_function('AbINS', e_init=request.param)
+    return abins, rf, request.param
+
+
+def test_panther_against_abins(panther_abins_plus_rf_abins_resolution_function):
+    abins, rf, energy = panther_abins_plus_rf_abins_resolution_function
+
+    frequencies = np.linspace(0, energy, 1000)
+
+    actual = rf(frequencies)
+    expected = abins.calculate_sigma(frequencies * MEV_TO_WAVENUMBER) * WAVENUMBER_TO_MEV
+
+    assert_allclose(actual, expected)

--- a/tests/integration_tests/test_panther.py
+++ b/tests/integration_tests/test_panther.py
@@ -18,20 +18,20 @@ def panther_rf():
 
 
 @pytest.fixture(scope="module", params=np.arange(0, 1209, 20), ids=lambda e: f'ei={e}')
-def panther_abins_plus_rf_abins_resolution_function(panther_rf, request):
-    abins = PantherInstrument()
-    abins.set_incident_energy(request.param, 'meV')
+def resolution_functions(panther_rf, request):
+    panther_abins = PantherInstrument()
+    panther_abins.set_incident_energy(request.param, 'meV')
 
     rf = panther_rf.get_resolution_function('AbINS', e_init=request.param)
-    return abins, rf, request.param
+    return panther_abins, rf, request.param
 
 
-def test_panther_against_abins(panther_abins_plus_rf_abins_resolution_function):
-    abins, rf, energy = panther_abins_plus_rf_abins_resolution_function
+def test_panther_against_abins(resolution_functions):
+    panther_abins, panther_resins, energy = resolution_functions
 
     frequencies = np.linspace(0, energy, 1000)
 
-    actual = rf(frequencies)
-    expected = abins.calculate_sigma(frequencies * MEV_TO_WAVENUMBER) * WAVENUMBER_TO_MEV
+    actual = panther_resins(frequencies)
+    expected = panther_abins.calculate_sigma(frequencies * MEV_TO_WAVENUMBER) * WAVENUMBER_TO_MEV
 
     assert_allclose(actual, expected)


### PR DESCRIPTION
Adds tests for the PANTHER instrument (testing against AbINS)

I have finally figured out why the tests for the PANTHER instrument have been a little bit off this entire time! I have been using a too-accurate conversion factor betwee meV and wavenumber - changing from `MEV_TO_WAVENUMBER = 1 / 0.12398419843320028` to `MEV_TO_WAVENUMBER = 8.06554465` (the value from `abins.constants`) has allowed the difference between ResINS results and AbINS results to come down to within the `assert_allclose` limits.