### PR TITLE
Move __call__ functionality to get_characteristics

### DIFF
--- a/src/resolution_functions/models/model_base.py
+++ b/src/resolution_functions/models/model_base.py
@@ -16,7 +16,17 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, ClassVar
+from typing import Any, ClassVar, TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from jaxtyping import Float
+
+
+DEPRECATION_MSG = 'The functionality of the __call__ method is going to soon change to return a ' \
+                  'convolution with data (see #10). For current functionality, use ' \
+                  'get_characteristics instead.'
 
 
 class InvalidInputError(Exception):
@@ -168,6 +178,25 @@ class InstrumentModel(ABC):
 
     def __init__(self, model_data: ModelData, **_):
         self._citation = model_data.citation
+
+    @abstractmethod
+    def get_characteristics(self, *args) -> dict[str, Float[np.ndarray, '...']]:
+        """
+        Computes the characteristics of the broadening function at each point in [Q, w] space
+        provided.
+
+        Parameters
+        ----------
+        *args
+            The independent variables at whose values to evaluate the model.
+
+        Returns
+        -------
+        characteristics
+            The characteristics of the broadening function at each combination of independent
+            variables.
+        """
+        raise NotImplementedError()
 
     @abstractmethod
     def __call__(self, *args, **kwargs):

--- a/src/resolution_functions/models/model_base.py
+++ b/src/resolution_functions/models/model_base.py
@@ -165,14 +165,11 @@ class InstrumentModel(ABC):
     ----------
     input
         The input that the ``__call__`` method expects.
-    output
-        The output of the ``__call__`` method.
     data_class
         The `ModelData` subclass associated with this particular model.
     citation
     """
-    input: ClassVar[int]
-    output: ClassVar[int]
+    input: ClassVar[tuple[str, ...]]
 
     data_class: ClassVar[type[ModelData]]
 

--- a/src/resolution_functions/models/panther_abins.py
+++ b/src/resolution_functions/models/panther_abins.py
@@ -79,8 +79,6 @@ class PantherAbINSModel(InstrumentModel):
     ----------
     input
         The input that the ``__call__`` method expects.
-    output
-        The output of the ``__call__`` method.
     data_class
         Reference to the `PantherAbINSModelData` type.
     abs : numpy.polynomial.polynomial.Polynomial
@@ -91,8 +89,7 @@ class PantherAbINSModel(InstrumentModel):
         The energy transfer and `e_init` product polynomial.
     citation
     """
-    input = 1
-    output = 1
+    input = ('energy_transfer',)
 
     data_class = PantherAbINSModelData
 

--- a/src/resolution_functions/models/panther_abins.py
+++ b/src/resolution_functions/models/panther_abins.py
@@ -117,7 +117,7 @@ class PantherAbINSModel(InstrumentModel):
         Returns
         -------
         characteristics
-            The characteristics of the broadening function, i.e. the Gaussian width as sigma.
+            The characteristics of the broadening function, i.e. the Gaussian width as sigma in meV.
         """
         resolution = (self.abs(energy_transfer) +
                       self.ei_dependence +

--- a/src/resolution_functions/models/panther_abins.py
+++ b/src/resolution_functions/models/panther_abins.py
@@ -9,11 +9,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+try:
+    from warnings import deprecated
+except ImportError:
+    from typing_extensions import deprecated
 
 import numpy as np
 from numpy.polynomial.polynomial import Polynomial
 
-from .model_base import InstrumentModel, ModelData
+from .model_base import InstrumentModel, ModelData, DEPRECATION_MSG
 
 if TYPE_CHECKING:
     from jaxtyping import Float
@@ -100,6 +104,30 @@ class PantherAbINSModel(InstrumentModel):
         self.ei_dependence = Polynomial(model_data.ei_dependence)(e_init)
         self.ei_energy_product = Polynomial(model_data.ei_energy_product)
 
+    def get_characteristics(self, energy_transfer: Float[np.ndarray, 'energy_transfer']
+                            ) -> dict[str, Float[np.ndarray, 'sigma']]:
+        """
+        Computes the broadening width at each value of `energy_transfer`
+
+        The model approximates the broadening using the Gaussian distribution, so the returned
+        widths are in the form of the standard deviation (sigma).
+
+        Parameters
+        ----------
+        energy_transfer
+            The energy transfer in meV at which to compute the broadening.
+
+        Returns
+        -------
+        characteristics
+            The characteristics of the broadening function, i.e. the Gaussian width as sigma.
+        """
+        resolution = (self.abs(energy_transfer) +
+                      self.ei_dependence +
+                      self.ei_energy_product(self.e_init * energy_transfer))
+        return {'sigma': resolution / (2 * np.sqrt(2 * np.log(2)))}
+
+    @deprecated(DEPRECATION_MSG)
     def __call__(self, frequencies: Float[np.ndarray, 'frequencies'], *args, **kwargs) -> Float[np.ndarray, 'sigma']:
         """
         Evaluates the model at given energy transfer values (`frequencies`), returning the
@@ -115,7 +143,4 @@ class PantherAbINSModel(InstrumentModel):
         sigma
             The Gaussian widths at `frequencies` as predicted by this model.
         """
-        resolution = (self.abs(frequencies) +
-                      self.ei_dependence +
-                      self.ei_energy_product(self.e_init * frequencies))
-        return resolution / (2 * np.sqrt(2 * np.log(2)))
+        return self.get_characteristics(frequencies)['sigma']

--- a/src/resolution_functions/models/polynomial.py
+++ b/src/resolution_functions/models/polynomial.py
@@ -61,16 +61,13 @@ class PolynomialModel1D(InstrumentModel):
     ----------
     input
         The input that the ``__call__`` method expects.
-    output
-        The output of the ``__call__`` method.
     data_class
         Reference to the `PolynomialModelData` type.
     polynomial : numpy.polynomial.polynomial.Polynomial
         The polynomial representing the resolution function.
     citation
     """
-    input = 1  # tuple of strings
-    output = 1
+    input = ('energy_transfer',)
 
     data_class: ClassVar[type[PolynomialModelData]] = PolynomialModelData
 
@@ -177,8 +174,6 @@ class DiscontinuousPolynomialModel1D(InstrumentModel):
     ----------
     input
         The input that the ``__call__`` method expects.
-    output
-        The output of the ``__call__`` method.
     data_class
         Reference to the `DiscontinuousPolynomialModelData` type.
     polynomial : numpy.polynomial.polynomial.Polynomial
@@ -197,8 +192,7 @@ class DiscontinuousPolynomialModel1D(InstrumentModel):
         `high_energy_cutoff`.
     citation
     """
-    input = 1
-    output = 1
+    input = ('energy_transfer',)
 
     data_class: ClassVar[type[DiscontinuousPolynomialModelData]] = DiscontinuousPolynomialModelData
 

--- a/src/resolution_functions/models/polynomial.py
+++ b/src/resolution_functions/models/polynomial.py
@@ -223,7 +223,7 @@ class DiscontinuousPolynomialModel1D(InstrumentModel):
         Returns
         -------
         characteristics
-            The characteristics of the broadening function, i.e. the Gaussian width as sigma.
+            The characteristics of the broadening function, i.e. the Gaussian width as sigma in meV.
         """
         result = self.polynomial(energy_transfer)
 

--- a/src/resolution_functions/models/polynomial.py
+++ b/src/resolution_functions/models/polynomial.py
@@ -9,11 +9,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import ClassVar, TYPE_CHECKING
+try:
+    from warnings import deprecated
+except ImportError:
+    from typing_extensions import deprecated
 
 import numpy as np
 from numpy.polynomial.polynomial import Polynomial
 
-from .model_base import InstrumentModel, ModelData
+from .model_base import InstrumentModel, ModelData, DEPRECATION_MSG
 
 if TYPE_CHECKING:
     from jaxtyping import Float
@@ -74,6 +78,27 @@ class PolynomialModel1D(InstrumentModel):
         super().__init__(model_data)
         self.polynomial = Polynomial(model_data.fit)
 
+    def get_characteristics(self, energy_transfer: Float[np.ndarray, 'energy_transfer']
+                            ) -> dict[str, Float[np.ndarray, 'sigma']]:
+        """
+        Computes the broadening width at each value of `energy_transfer`.
+
+        The model approximates the broadening using the Gaussian distribution, so the returned
+        widths are in the form of the standard deviation (sigma).
+
+        Parameters
+        ----------
+        energy_transfer
+            The energy transfer in meV at which to compute the broadening.
+
+        Returns
+        -------
+        characteristics
+            The characteristics of the broadening function, i.e. the Gaussian width as sigma.
+        """
+        return {'sigma': self.polynomial(energy_transfer)}
+
+    @deprecated(DEPRECATION_MSG)
     def __call__(self, frequencies: Float[np.ndarray, 'frequencies'], *args, **kwargs
                  ) -> Float[np.ndarray, 'sigma']:
         """
@@ -90,7 +115,7 @@ class PolynomialModel1D(InstrumentModel):
         sigma
             The Gaussian widths at `frequencies` as predicted by this model.
         """
-        return self.polynomial(frequencies)
+        return self.get_characteristics(frequencies)['sigma']
 
 
 @dataclass(init=True, repr=True, frozen=True, slots=True, kw_only=True)
@@ -188,6 +213,34 @@ class DiscontinuousPolynomialModel1D(InstrumentModel):
         self.high_energy_cutoff = model_data.high_energy_cutoff
         self.high_energy_resolution = model_data.high_energy_resolution
 
+    def get_characteristics(self, energy_transfer: Float[np.ndarray, 'energy_transfer']
+                            ) -> dict[str, Float[np.ndarray, 'sigma']]:
+        """
+        Computes the broadening width at each value of `energy_transfer`.
+
+        The model approximates the broadening using the Gaussian distribution, so the returned
+        widths are in the form of the standard deviation (sigma).
+
+        Parameters
+        ----------
+        energy_transfer
+            The energy transfer in meV at which to compute the broadening.
+
+        Returns
+        -------
+        characteristics
+            The characteristics of the broadening function, i.e. the Gaussian width as sigma.
+        """
+        result = self.polynomial(energy_transfer)
+
+        assert np.all(result > 0)
+
+        result[energy_transfer < self.low_energy_cutoff] = self.low_energy_resolution
+        result[energy_transfer > self.high_energy_cutoff] = self.high_energy_resolution
+
+        return {'sigma': result * 0.5}
+
+    @deprecated(DEPRECATION_MSG)
     def __call__(self, frequencies: Float[np.ndarray, 'frequencies']) -> Float[np.ndarray, 'sigma']:
         """
         Evaluates the model at given energy transfer values (`frequencies`), returning the
@@ -208,11 +261,4 @@ class DiscontinuousPolynomialModel1D(InstrumentModel):
         AssertionError
             If any of the widths are negative.
         """
-        result = self.polynomial(frequencies)
-
-        assert np.all(result > 0)
-
-        result[frequencies < self.low_energy_cutoff] = self.low_energy_resolution
-        result[frequencies > self.high_energy_cutoff] = self.high_energy_resolution
-
-        return result * 0.5
+        return self.get_characteristics(frequencies)['sigma']

--- a/src/resolution_functions/models/pychop.py
+++ b/src/resolution_functions/models/pychop.py
@@ -30,12 +30,16 @@ try:
 except ImportError:
     from typing_extensions import NotRequired, TypedDict
 
+try:
+    from warnings import deprecated
+except ImportError:
+    from typing_extensions import deprecated
 
 import numpy as np
 from numpy.polynomial.polynomial import Polynomial
 from scipy.interpolate import interp1d
 
-from .model_base import InstrumentModel, ModelData, InvalidInputError
+from .model_base import InstrumentModel, ModelData, InvalidInputError, DEPRECATION_MSG
 
 if TYPE_CHECKING:
     from jaxtyping import Float
@@ -408,6 +412,27 @@ class PyChopModel(InstrumentModel, ABC):
 
     data_class = PyChopModelData
 
+    def get_characteristics(self, energy_transfer: Float[np.ndarray, 'energy_transfer']
+                            ) -> dict[str, Float[np.ndarray, 'sigma']]:
+        """
+        Computes the broadening width at each value of `energy_transfer`.
+
+        The model approximates the broadening using the Gaussian distribution, so the returned
+        widths are in the form of the standard deviation (sigma).
+
+        Parameters
+        ----------
+        energy_transfer
+            The energy transfer in meV at which to compute the broadening.
+
+        Returns
+        -------
+        characteristics
+            The characteristics of the broadening function, i.e. the Gaussian width as sigma.
+        """
+        return {'sigma': self.polynomial(energy_transfer)}
+
+    @deprecated(DEPRECATION_MSG)
     def __call__(self, frequencies: Float[np.ndarray, 'frequencies'], *args, **kwargs
                  ) -> Float[np.ndarray, 'sigma']:
         """
@@ -424,7 +449,7 @@ class PyChopModel(InstrumentModel, ABC):
         sigma
             The Gaussian widths at `frequencies` as predicted by this model.
         """
-        return self.polynomial(frequencies)
+        return self.get_characteristics(frequencies)['sigma']
 
     @property
     @abstractmethod

--- a/src/resolution_functions/models/pychop.py
+++ b/src/resolution_functions/models/pychop.py
@@ -400,15 +400,12 @@ class PyChopModel(InstrumentModel, ABC):
     ----------
     input
         The input that the ``__call__`` method expects.
-    output
-        The output of the ``__call__`` method.
     data_class
         Reference to the `PyChopModelData` type.
     citation
     polynomial
     """
-    input = 1
-    output = 1
+    input = ('energy_transfer',)
 
     data_class = PyChopModelData
 
@@ -1003,8 +1000,6 @@ class PyChopModelFermi(PyChopModel):
     ----------
     input
         The input that the ``__call__`` method expects.
-    output
-        The output of the ``__call__`` method.
     data_class
         Reference to the `PyChopModelDataFermi` type.
     citation
@@ -1358,8 +1353,6 @@ class PyChopModelCNCS(PyChopModelNonFermi):
     ----------
     input
         The input that the ``__call__`` method expects.
-    output
-        The output of the ``__call__`` method.
     data_class
         Reference to the `PyChopModelDataNonFermi` type.
     citation
@@ -1435,8 +1428,6 @@ class PyChopModelLET(PyChopModelNonFermi):
     ----------
     input
         The input that the ``__call__`` method expects.
-    output
-        The output of the ``__call__`` method.
     data_class
         Reference to the `PyChopModelDataNonFermi` type.
     citation

--- a/src/resolution_functions/models/pychop.py
+++ b/src/resolution_functions/models/pychop.py
@@ -420,12 +420,12 @@ class PyChopModel(InstrumentModel, ABC):
         Parameters
         ----------
         energy_transfer
-            The energy transfer in meV at which to compute the broadening.
+            The energy transfer in meV at which to compute the broadening in meV.
 
         Returns
         -------
         characteristics
-            The characteristics of the broadening function, i.e. the Gaussian width as sigma.
+            The characteristics of the broadening function, i.e. the Gaussian width as sigma in meV.
         """
         return {'sigma': self.polynomial(energy_transfer)}
 

--- a/src/resolution_functions/models/tosca_book.py
+++ b/src/resolution_functions/models/tosca_book.py
@@ -139,7 +139,7 @@ class ToscaBookModel(InstrumentModel):
         Computes the broadening width at each value of `energy_transfer`.
 
         The model approximates the broadening using the Gaussian distribution, so the returned
-        widths are in the form of the standard deviation (sigma).
+        widths are in the form of the standard deviation (sigma) in meV.
 
         Parameters
         ----------

--- a/src/resolution_functions/models/tosca_book.py
+++ b/src/resolution_functions/models/tosca_book.py
@@ -102,14 +102,11 @@ class ToscaBookModel(InstrumentModel):
     ----------
     input
         The input that the ``__call__`` method expects.
-    output
-        The output of the ``__call__`` method.
     data_class
         Reference to the `ToscaBookModelData` type.
     citation
     """
-    input = 1
-    output = 1
+    input = ('energy_transfer',)
 
     data_class = ToscaBookModelData
 

--- a/src/resolution_functions/models/tosca_book.py
+++ b/src/resolution_functions/models/tosca_book.py
@@ -11,10 +11,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+try:
+    from warnings import deprecated
+except ImportError:
+    from typing_extensions import deprecated
 
 import numpy as np
 
-from .model_base import InstrumentModel, ModelData
+from .model_base import InstrumentModel, ModelData, DEPRECATION_MSG
 
 if TYPE_CHECKING:
     from jaxtyping import Float
@@ -132,6 +136,45 @@ class ToscaBookModel(InstrumentModel):
         self.average_bragg_angle = model_data.average_bragg_angle_graphite
         self.time_channel_uncertainty2 = model_data.time_channel_uncertainty ** 2
 
+    def get_characteristics(self, energy_transfer: Float[np.ndarray, 'energy_transfer']
+                            ) -> dict[str, Float[np.ndarray, 'sigma']]:
+        """
+        Computes the broadening width at each value of `energy_transfer`.
+
+        The model approximates the broadening using the Gaussian distribution, so the returned
+        widths are in the form of the standard deviation (sigma).
+
+        Parameters
+        ----------
+        energy_transfer
+            The energy transfer in meV at which to compute the broadening.
+
+        Returns
+        -------
+        characteristics
+            The characteristics of the broadening function, i.e. the Gaussian width as sigma.
+        """
+        ei = energy_transfer + self.average_final_energy
+
+        time_dependent_term = (2 / NEUTRON_MASS) ** 0.5 * ei ** 1.5 / self.primary_flight_path
+        time_dependent_term *= self.time_dependent_term_factor / (
+                    2 * NEUTRON_MASS * ei) + self.time_channel_uncertainty2
+
+        incident_flight_term = 2 * ei / self.primary_flight_path * self.primary_flight_path_uncertainty
+
+        final_energy_term = (self.time_dependent_term_factor *
+                             (1 + self.average_secondary_flight_path / self.primary_flight_path *
+                              (ei / self.average_final_energy) ** 1.5))
+
+        final_flight_term = (2 / self.average_secondary_flight_path *
+                             np.sqrt(ei ** 3 / self.average_final_energy) *
+                             2 * self.primary_flight_path / np.sin(self.average_bragg_angle))
+
+        result =  np.sqrt(time_dependent_term ** 2 + incident_flight_term ** 2 +
+                          final_energy_term ** 2 + final_flight_term ** 2)
+        return {'sigma': result}
+
+    @deprecated(DEPRECATION_MSG)
     def __call__(self, frequencies: Float[np.ndarray, 'frequencies'], *args, **kwargs) -> Float[np.ndarray, 'sigma']:
         """
         Evaluates the model at given energy transfer values (`frequencies`), returning the
@@ -147,20 +190,4 @@ class ToscaBookModel(InstrumentModel):
         sigma
             The Gaussian widths at `frequencies` as predicted by this model.
         """
-        ei = frequencies + self.average_final_energy
-
-        time_dependent_term = (2 / NEUTRON_MASS) ** 0.5 * ei ** 1.5 / self.primary_flight_path
-        time_dependent_term *= self.time_dependent_term_factor / (2 * NEUTRON_MASS * ei) + self.time_channel_uncertainty2
-
-        incident_flight_term = 2 * ei / self.primary_flight_path * self.primary_flight_path_uncertainty
-
-        final_energy_term = (self.time_dependent_term_factor *
-                             (1 + self.average_secondary_flight_path / self.primary_flight_path *
-                              (ei / self.average_final_energy) ** 1.5))
-
-        final_flight_term = (2 / self.average_secondary_flight_path *
-                             np.sqrt(ei ** 3 / self.average_final_energy) *
-                             2 * self.primary_flight_path / np.sin(self.average_bragg_angle))
-
-        return np.sqrt(time_dependent_term ** 2 + incident_flight_term ** 2 +
-                       final_energy_term ** 2 + final_flight_term ** 2)
+        return self.get_characteristics(frequencies)['sigma']

--- a/src/resolution_functions/models/vision_paper.py
+++ b/src/resolution_functions/models/vision_paper.py
@@ -88,14 +88,11 @@ class VisionPaperModel(InstrumentModel):
     ----------
     input
         The input that the ``__call__`` method expects.
-    output
-        The output of the ``__call__`` method.
     data_class
         Reference to the `VisionPaperModelData` type.
     citation
     """
-    input = 1
-    output = 1
+    input = ('energy_transfer',)
 
     data_class = VisionPaperModelData
 

--- a/src/resolution_functions/models/vision_paper.py
+++ b/src/resolution_functions/models/vision_paper.py
@@ -10,11 +10,15 @@ obtaining the :term:`resolution function` of an :term:`instrument`, please use t
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
+try:
+    from warnings import deprecated
+except ImportError:
+    from typing_extensions import deprecated
 
 import numpy as np
 
-from .model_base import InstrumentModel, ModelData
+from .model_base import InstrumentModel, ModelData, DEPRECATION_MSG
 
 if TYPE_CHECKING:
     from jaxtyping import Float
@@ -123,6 +127,37 @@ class VisionPaperModel(InstrumentModel):
 
         self.final_term = self.e0 / np.tan(self.theta) / self.z2 * model_data.d_r
 
+    def get_characteristics(self, energy_transfer: Float[np.ndarray, 'energy_transfer']
+                            ) -> dict[str, Float[np.ndarray, 'sigma']]:
+        """
+        Computes the broadening width at each value of `energy_transfer`.
+
+        The model approximates the broadening using the Gaussian distribution, so the returned
+        widths are in the form of the standard deviation (sigma).
+
+        Parameters
+        ----------
+        energy_transfer
+            The energy transfer in meV at which to compute the broadening.
+
+        Returns
+        -------
+        characteristics
+            The characteristics of the broadening function, i.e. the Gaussian width as sigma.
+        """
+        e1 = energy_transfer * self.REDUCED_PLANCK + self.e0 * (1 / np.sin(self.theta))
+        z0 = self.l1 * (self.e0 / e1) ** 0.5
+        one_over_z0 = 1 / z0
+
+        sigma = self.distance_ratio - self.nu0 * self.d_t / z0
+        sigma += (self.one_over_l1 + one_over_z0 + self.capital_t_over_z2) * self.d_a
+        sigma += (one_over_z0 + self.capital_t_over_z2) * self.db_dc_factor
+        sigma *= 2 * e1
+        sigma -= self.final_term
+
+        return {'sigma': sigma}
+
+    @deprecated(DEPRECATION_MSG)
     def __call__(self, frequencies: Float[np.ndarray, 'frequencies']) -> Float[np.ndarray, 'sigma']:
         """
         Evaluates the model at given energy transfer values (`frequencies`), returning the
@@ -138,14 +173,4 @@ class VisionPaperModel(InstrumentModel):
         fwhm
             The Ikeda-Carpenter widths at `frequencies` as predicted by this model.
         """
-        e1 = frequencies * self.REDUCED_PLANCK + self.e0 * (1 / np.sin(self.theta))
-        z0 = self.l1 * (self.e0 / e1) ** 0.5
-        one_over_z0 = 1 / z0
-
-        sigma = self.distance_ratio - self.nu0 * self.d_t / z0
-        sigma += (self.one_over_l1 + one_over_z0 + self.capital_t_over_z2) * self.d_a
-        sigma += (one_over_z0 + self.capital_t_over_z2) * self.db_dc_factor
-        sigma *= 2 * e1
-        sigma -= self.final_term
-
-        return sigma
+        return self.get_characteristics(frequencies)['sigma']


### PR DESCRIPTION
Resolves #25 

- A new method (`get_characteristics`) added to all instrument models where the previous functionality of `__call__` has been moved
- A deprecation warning has been added to the current implementation of `__call__`
- The `output` class variable has been removed
- The `input` class variable has been changed to a tuple of strings